### PR TITLE
fix!: use instance uri instead of conn name

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -64,7 +64,7 @@ func TestDialerCanConnectToInstance(t *testing.T) {
 	}
 	d.client = c
 
-	conn, err := d.Dial(ctx, "my-project:my-region:my-cluster:my-instance")
+	conn, err := d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	if err != nil {
 		t.Fatalf("expected Dial to succeed, but got error: %v", err)
 	}
@@ -106,12 +106,12 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	cancel()
 
-	_, err = d.Dial(ctx, "my-project:my-region:my-cluster:my-instance")
+	_, err = d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("when context is canceled, want = %T, got = %v", context.Canceled, err)
 	}
 
-	_, err = d.Dial(context.Background(), "my-project:my-region:my-cluster:my-instance")
+	_, err = d.Dial(context.Background(), "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	var wantErr2 *errtype.RefreshError
 	if !errors.As(err, &wantErr2) {
 		t.Fatalf("when API call fails, want = %T, got = %v", wantErr2, err)
@@ -144,7 +144,7 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 	}
 	d.client = c
 
-	_, err = d.Dial(ctx, "my-project:my-region:my-cluster:my-instance")
+	_, err = d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	var wantErr2 *errtype.DialError
 	if !errors.As(err, &wantErr2) {
 		t.Fatalf("when server proxy socket is unavailable, want = %T, got = %v", wantErr2, err)
@@ -155,7 +155,7 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 
 	// TODO: restore this test and figure out why the test proxy server isn't
 	// rejected an invalid client certificate.
-	// _, err = d.Dial(ctx, "my-project:my-region:my-cluster:my-instance")
+	// _, err = d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	// if !errors.As(err, &wantErr2) {
 	// 	t.Fatalf("when TLS handshake fails, want = %T, got = %v", wantErr2, err)
 	// }
@@ -193,7 +193,7 @@ func TestDialerWithCustomDialFunc(t *testing.T) {
 	}
 	d.client = c
 
-	_, err = d.Dial(ctx, "my-project:my-region:my-cluster:my-instance")
+	_, err = d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	if !strings.Contains(err.Error(), "sentinel error") {
 		t.Fatalf("want = sentinel error, got = %v", err)
 	}

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -41,16 +41,16 @@ func genRSAKey() *rsa.PrivateKey {
 // RSAKey is used for test only.
 var RSAKey = genRSAKey()
 
-func TestParseConnName(t *testing.T) {
+func TestParseInstURI(t *testing.T) {
 	tcs := []struct {
 		desc string
 		in   string
-		want connName
+		want instanceURI
 	}{
 		{
 			desc: "vanilla instance connection name",
-			in:   "proj:reg:clust:name",
-			want: connName{
+			in:   "/projects/proj/locations/reg/clusters/clust/instances/name",
+			want: instanceURI{
 				project: "proj",
 				region:  "reg",
 				cluster: "clust",
@@ -59,8 +59,8 @@ func TestParseConnName(t *testing.T) {
 		},
 		{
 			desc: "with legacy domain-scoped project",
-			in:   "google.com:proj:reg:clust:name",
-			want: connName{
+			in:   "/projects/google.com:proj/locations/reg/clusters/clust/instances/name",
+			want: instanceURI{
 				project: "google.com:proj",
 				region:  "reg",
 				cluster: "clust",
@@ -71,7 +71,7 @@ func TestParseConnName(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := parseConnName(tc.in)
+			got, err := parseInstURI(tc.in)
 			if err != nil {
 				t.Fatalf("want no error, got = %v", err)
 			}
@@ -107,7 +107,7 @@ func TestParseConnNameErrors(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := parseConnName(tc.in)
+			_, err := parseInstURI(tc.in)
 			if err == nil {
 				t.Fatal("want error, got nil")
 			}
@@ -149,7 +149,7 @@ func TestConnectInfo(t *testing.T) {
 	}
 
 	i, err := NewInstance(
-		"my-project:my-region:my-cluster:my-instance",
+		"/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance",
 		c, RSAKey, 30*time.Second, "dialer-id",
 	)
 	if err != nil {
@@ -188,7 +188,7 @@ func TestConnectInfoErrors(t *testing.T) {
 
 	// Use a timeout that should fail instantly
 	im, err := NewInstance(
-		"my-project:my-region:my-cluster:my-instance",
+		"/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance",
 		c, RSAKey, 0, "dialer-id",
 	)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestClose(t *testing.T) {
 
 	// Set up an instance and then close it immediately
 	im, err := NewInstance(
-		"my-proj:my-region:my-cluster:my-inst",
+		"/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance",
 		c, RSAKey, 30, "dialer-ider",
 	)
 	if err != nil {

--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -36,7 +36,7 @@ import (
 // fetchMetadata uses the AlloyDB Admin APIs get method to retreive the
 // information about an AlloyDB instance that is used to create secure
 // connections.
-func fetchMetadata(ctx context.Context, cl *alloydbapi.Client, inst connName) (ipAddr string, err error) {
+func fetchMetadata(ctx context.Context, cl *alloydbapi.Client, inst instanceURI) (ipAddr string, err error) {
 	var end trace.EndSpanFunc
 	ctx, end = trace.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.FetchMetadata")
 	defer func() { end(err) }()
@@ -64,7 +64,7 @@ func parseCert(cert string) (*x509.Certificate, error) {
 func fetchEphemeralCert(
 	ctx context.Context,
 	cl *alloydbapi.Client,
-	inst connName,
+	inst instanceURI,
 	key *rsa.PrivateKey,
 ) (cc certChain, err error) {
 	var end trace.EndSpanFunc
@@ -140,7 +140,7 @@ func fetchEphemeralCert(
 
 // createTLSConfig returns a *tls.Config for connecting securely to the AlloyDB
 // instance.
-func createTLSConfig(inst connName, cc certChain, k *rsa.PrivateKey) *tls.Config {
+func createTLSConfig(inst instanceURI, cc certChain, k *rsa.PrivateKey) *tls.Config {
 	certs := x509.NewCertPool()
 	certs.AddCert(cc.root)
 
@@ -235,7 +235,7 @@ type certChain struct {
 	client       *x509.Certificate
 }
 
-func (r refresher) performRefresh(ctx context.Context, cn connName, k *rsa.PrivateKey) (res refreshResult, err error) {
+func (r refresher) performRefresh(ctx context.Context, cn instanceURI, k *rsa.PrivateKey) (res refreshResult, err error) {
 	var refreshEnd trace.EndSpanFunc
 	ctx, refreshEnd = trace.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.RefreshConnection",
 		trace.AddInstanceName(cn.String()),

--- a/internal/alloydb/refresh_test.go
+++ b/internal/alloydb/refresh_test.go
@@ -29,8 +29,8 @@ import (
 func TestRefresh(t *testing.T) {
 	wantIP := "10.0.0.1"
 	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
-	wantConnName := "my-project:my-region:my-cluster:my-instance"
-	cn, err := parseConnName(wantConnName)
+	wantInstURI := "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"
+	cn, err := parseInstURI(wantInstURI)
 	if err != nil {
 		t.Fatalf("parseConnName(%s)failed : %v", cn, err)
 	}
@@ -72,8 +72,8 @@ func TestRefresh(t *testing.T) {
 }
 
 func TestRefreshFailsFast(t *testing.T) {
-	wantConnName := "my-project:my-region:my-cluster:my-instance"
-	cn, err := parseConnName(wantConnName)
+	wantInstURI := "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"
+	cn, err := parseInstURI(wantInstURI)
 	if err != nil {
 		t.Fatalf("parseConnName(%s)failed : %v", cn, err)
 	}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -128,13 +128,13 @@ func TestDialerWithMetrics(t *testing.T) {
 	d.client = c
 
 	// dial a good instance
-	conn, err := d.Dial(ctx, "my-project:my-region:my-cluster:my-instance")
+	conn, err := d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance")
 	if err != nil {
 		t.Fatalf("expected Dial to succeed, but got error: %v", err)
 	}
 	defer conn.Close()
 	// dial a bogus instance
-	_, err = d.Dial(ctx, "my-project:my-region:notaninstance")
+	_, err = d.Dial(ctx, "/projects/my-project/locations/my-region/clusters/my-cluster/instances/notaninstance")
 	if err == nil {
 		t.Fatal("expected Dial to fail, but got no error")
 	}


### PR DESCRIPTION
## Change Description

Cloud SQL uses a connection name, but AlloyDB uses instance URI