### PR TITLE
chore(ci): add unit tests for 32-bit linux and windows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,14 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         go-version: [1.16, 1.17, 1.18]
+        arch: ["386", "amd64"]
+        exclude:
+          - os: macos-latest
+            arch: "386"
+          - go-version: 1.16
+            arch: "386"
+          - go-version: 1.17
+            arch: "386"
     steps:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
@@ -64,4 +72,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Run tests
         run: |
-          go test -v -race -cover -short ./...
+          GOARCH=${{matrix.arch}} go test -v -race -cover -short ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,14 +55,6 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         go-version: [1.16, 1.17, 1.18]
-        arch: ["386", "amd64"]
-        exclude:
-          - os: macos-latest
-            arch: "386"
-          - go-version: 1.16
-            arch: "386"
-          - go-version: 1.17
-            arch: "386"
     steps:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
@@ -72,4 +64,20 @@ jobs:
         uses: actions/checkout@v3
       - name: Run tests
         run: |
-          GOARCH=${{matrix.arch}} go test -v -race -cover -short ./...
+          go test -v -race -cover -short ./...
+  build-32bit:
+    name: "unit tests (386)"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - name: Setup Go 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: |
+          GOARCH=386 go test -v -cover -short ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,7 @@ jobs:
       strategy:
         matrix:
           go-version: [1.16, 1.17, 1.18]
+        fail-fast: false
       steps:
         - name: Setup Go ${{ matrix.go-version }}
           uses: actions/setup-go@v3
@@ -55,6 +56,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         go-version: [1.16, 1.17, 1.18]
+      fail-fast: false
     steps:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
@@ -71,6 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
+      fail-fast: false
     steps:
       - name: Setup Go 1.18
         uses: actions/setup-go@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,6 +74,8 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
       fail-fast: false
+    env:
+      GOARCH: 386
     steps:
       - name: Setup Go 1.18
         uses: actions/setup-go@v3
@@ -83,4 +85,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Run tests
         run: |
-          GOARCH=386 go test -v -cover -short ./...
+          go test -v -cover -short ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           go test -v -race -cover -short ./...
   build-32bit:
-    name: "unit tests (386)"
+    name: "unit tests (32-bit)"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Change Description

Run unit tests on 32-bit Linux and Windows with latest Go version. Need to merge https://github.com/GoogleCloudPlatform/alloydb-go-connector/pull/33 first

fixes: #30 