### PR TITLE
fix: adjust alignment for 32-bit arch

### DIFF
--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -127,7 +127,7 @@ func (r *refreshOperation) IsValid() bool {
 type Instance struct {
 	// OpenConns is the number of open connections to the instance.
 	OpenConns uint64
-	
+
 	instanceURI
 	key *rsa.PrivateKey
 	r   refresher

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -125,6 +125,9 @@ func (r *refreshOperation) IsValid() bool {
 // required information approximately 5 minutes before the previous certificate
 // expires (every 55 minutes).
 type Instance struct {
+	// OpenConns is the number of open connections to the instance.
+	OpenConns uint64
+	
 	instanceURI
 	key *rsa.PrivateKey
 	r   refresher
@@ -136,9 +139,6 @@ type Instance struct {
 	// next represents a future or ongoing refreshOperation. Once complete, it will replace cur and schedule a
 	// replacement to occur.
 	next *refreshOperation
-
-	// OpenConns is the number of open connections to the instance.
-	OpenConns uint64
 
 	// ctx is the default ctx for refresh operations. Canceling it prevents new refresh
 	// operations from being triggered.


### PR DESCRIPTION
## Change Description

This fixes the `panic: unaligned 64-bit atomic operation` error on 386 architectures.


## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/27