### PR TITLE
fix: prevent repeated context expired errors

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -94,7 +94,7 @@ type Dialer struct {
 // RSA keypair is generated will be faster.
 func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	cfg := &dialerConfig{
-		refreshTimeout: 30 * time.Second,
+		refreshTimeout: alloydb.RefreshTimeout,
 		dialFunc:       proxy.Dial,
 		useragents:     []string{userAgent},
 	}

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -210,7 +211,7 @@ func TestClose(t *testing.T) {
 	im.Close()
 
 	_, _, err = im.ConnectInfo(ctx)
-	if !errors.Is(err, context.Canceled) {
+	if !strings.Contains(err.Error(), "context was canceled or expired") {
 		t.Fatalf("failed to retrieve connect info: %v", err)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -116,7 +116,8 @@ func WithRSAKey(k *rsa.PrivateKey) Option {
 	}
 }
 
-// WithRefreshTimeout returns an Option that sets a timeout on refresh operations. Defaults to 30s.
+// WithRefreshTimeout returns an Option that sets a timeout on refresh
+// operations. Defaults to 60s.
 func WithRefreshTimeout(t time.Duration) Option {
 	return func(d *dialerConfig) {
 		d.refreshTimeout = t


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/458.