### PR TITLE
fix: require TLS 1.3 always

### DIFF
--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -273,6 +273,7 @@ func (r refresher) performRefresh(ctx context.Context, cn InstanceURI, k *rsa.Pr
 		Certificates: []tls.Certificate{cc.certChain},
 		RootCAs:      caCerts,
 		ServerName:   info.ipAddr,
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	return refreshResult{instanceIPAddr: info.ipAddr, conf: c, expiry: cc.expiry}, nil


### PR DESCRIPTION
This is more of documentation change, as the server only supports TLS 1.3.