### PR TITLE
fix: remove leading slash from metric names

### DIFF
--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -33,33 +33,33 @@ var (
 	keyErrorCode, _ = tag.NewKey("alloydb_error_code")
 
 	mLatencyMS = stats.Int64(
-		"/alloydbconn/latency",
+		"alloydbconn/latency",
 		"The latency in milliseconds per Dial",
 		stats.UnitMilliseconds,
 	)
 	mConnections = stats.Int64(
-		"/alloydbconn/connection",
+		"alloydbconn/connection",
 		"A connect or disconnect event to an AlloyDB instance",
 		stats.UnitDimensionless,
 	)
 	mDialError = stats.Int64(
-		"/alloydbconn/dial_failure",
+		"alloydbconn/dial_failure",
 		"A failure to dial an AlloyDB instance",
 		stats.UnitDimensionless,
 	)
 	mSuccessfulRefresh = stats.Int64(
-		"/alloydbconn/refresh_success",
+		"alloydbconn/refresh_success",
 		"A successful certificate refresh operation",
 		stats.UnitDimensionless,
 	)
 	mFailedRefresh = stats.Int64(
-		"/alloydbconn/refresh_failure",
+		"alloydbconn/refresh_failure",
 		"A failed certificate refresh operation",
 		stats.UnitDimensionless,
 	)
 
 	latencyView = &view.View{
-		Name:        "/alloydbconn/dial_latency",
+		Name:        "alloydbconn/dial_latency",
 		Measure:     mLatencyMS,
 		Description: "The distribution of dialer latencies (ms)",
 		// Latency in buckets, e.g., >=0ms, >=100ms, etc.
@@ -67,28 +67,28 @@ var (
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	connectionsView = &view.View{
-		Name:        "/alloydbconn/open_connections",
+		Name:        "alloydbconn/open_connections",
 		Measure:     mConnections,
 		Description: "The current number of open AlloyDB connections",
 		Aggregation: view.LastValue(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	dialFailureView = &view.View{
-		Name:        "/alloydbconn/dial_failure_count",
+		Name:        "alloydbconn/dial_failure_count",
 		Measure:     mDialError,
 		Description: "The number of failed dial attempts",
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	refreshCountView = &view.View{
-		Name:        "/alloydbconn/refresh_success_count",
+		Name:        "alloydbconn/refresh_success_count",
 		Measure:     mSuccessfulRefresh,
 		Description: "The number of successful certificate refresh operations",
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID},
 	}
 	failedRefreshCountView = &view.View{
-		Name:        "/alloydbconn/refresh_failure_count",
+		Name:        "alloydbconn/refresh_failure_count",
 		Measure:     mFailedRefresh,
 		Description: "The number of failed certificate refresh operations",
 		Aggregation: view.Count(),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -71,6 +71,7 @@ func wantLastValueMetric(t *testing.T, wantName string, ms []metric) {
 // wantDistributionMetric ensures the provided metrics include a metric with the
 // wanted name and at least one data point.
 func wantDistributionMetric(t *testing.T, wantName string, ms []metric) {
+	t.Helper()
 	gotNames := make(map[string]view.AggregationData)
 	for _, m := range ms {
 		gotNames[m.name] = m.data
@@ -85,6 +86,7 @@ func wantDistributionMetric(t *testing.T, wantName string, ms []metric) {
 // wantCountMetric ensures the provided metrics include a metric with the wanted
 // name and at least one data point.
 func wantCountMetric(t *testing.T, wantName string, ms []metric) {
+	t.Helper()
 	gotNames := make(map[string]view.AggregationData)
 	for _, m := range ms {
 		gotNames[m.name] = m.data
@@ -143,11 +145,11 @@ func TestDialerWithMetrics(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // allow exporter a chance to run
 
 	// success metrics
-	wantLastValueMetric(t, "/alloydbconn/open_connections", spy.Data())
-	wantDistributionMetric(t, "/alloydbconn/dial_latency", spy.Data())
-	wantCountMetric(t, "/alloydbconn/refresh_success_count", spy.Data())
+	wantLastValueMetric(t, "alloydbconn/open_connections", spy.Data())
+	wantDistributionMetric(t, "alloydbconn/dial_latency", spy.Data())
+	wantCountMetric(t, "alloydbconn/refresh_success_count", spy.Data())
 
 	// failure metrics from dialing bogus instance
-	wantCountMetric(t, "/alloydbconn/dial_failure_count", spy.Data())
-	wantCountMetric(t, "/alloydbconn/refresh_failure_count", spy.Data())
+	wantCountMetric(t, "alloydbconn/dial_failure_count", spy.Data())
+	wantCountMetric(t, "alloydbconn/refresh_failure_count", spy.Data())
 }


### PR DESCRIPTION
This is a port of
https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/393.

Fixes #311.