### PR TITLE
fix: re-use current connection info during force refresh

### DIFF
--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -205,8 +205,6 @@ func (i *Instance) ForceRefresh() {
 	if i.next.cancel() {
 		i.next = i.scheduleRefresh(0)
 	}
-	// block all sequential connection attempts on the next refresh result
-	i.cur = i.next
 }
 
 // result returns the most recent refresh result (waiting for it to complete if


### PR DESCRIPTION
This change makes it possible for the current info to remain usable while a force refresh is in progress. This ensures that otherwise valid connection info isn't thrown away during passing network problems.