### PR TITLE
Revert "chore: prefer public key in API requests"

### DIFF
--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -17,9 +17,11 @@ package alloydb
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -82,9 +84,24 @@ func fetchEphemeralCert(
 	ctx, end = trace.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.FetchEphemeralCert")
 	defer func() { end(err) }()
 
+	subj := pkix.Name{
+		CommonName:         "alloydb-proxy",
+		Country:            []string{"US"},
+		Province:           []string{"CA"},
+		Locality:           []string{"Sunnyvale"},
+		Organization:       []string{"Google LLC"},
+		OrganizationalUnit: []string{"Cloud"},
+	}
+	tmpl := x509.CertificateRequest{
+		Subject:            subj,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &tmpl, key)
+	if err != nil {
+		return nil, err
+	}
 	buf := &bytes.Buffer{}
-	k := x509.MarshalPKCS1PublicKey(&key.PublicKey)
-	err = pem.Encode(buf, &pem.Block{Type: "RSA PUBLIC KEY", Bytes: k})
+	err = pem.Encode(buf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +109,7 @@ func fetchEphemeralCert(
 		Parent: fmt.Sprintf(
 			"projects/%s/locations/%s/clusters/%s", inst.project, inst.region, inst.cluster,
 		),
-		PublicKey:    buf.String(),
+		PemCsr:       buf.String(),
 		CertDuration: durationpb.New(time.Second * 3600),
 	}
 	resp, err := cl.GenerateClientCertificate(ctx, req)

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -101,25 +101,29 @@ func CreateEphemeralSuccess(i FakeAlloyDBInstance, ct int) *Request {
 				http.Error(resp, fmt.Errorf("invalid or unexpected json: %w", err).Error(), http.StatusBadRequest)
 				return
 			}
-			bl, _ := pem.Decode([]byte(rreq.PublicKey))
+			bl, _ := pem.Decode([]byte(rreq.PemCsr))
 			if bl == nil {
 				http.Error(resp, fmt.Errorf("unable to decode CSR: %w", err).Error(), http.StatusBadRequest)
 				return
 			}
-			pub, err := x509.ParsePKCS1PublicKey(bl.Bytes)
+			csr, err := x509.ParseCertificateRequest(bl.Bytes)
 			if err != nil {
 				http.Error(resp, fmt.Errorf("unable to decode CSR: %w", err).Error(), http.StatusBadRequest)
 				return
 			}
 
 			template := &x509.Certificate{
-				PublicKey:    pub,
-				SerialNumber: &big.Int{},
-				Issuer:       i.intermedCert.Subject,
-				NotBefore:    time.Now(),
-				NotAfter:     i.certExpiry,
-				KeyUsage:     x509.KeyUsageDigitalSignature,
-				ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				Signature:          csr.Signature,
+				SignatureAlgorithm: csr.SignatureAlgorithm,
+				PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+				PublicKey:          csr.PublicKey,
+				SerialNumber:       &big.Int{},
+				Issuer:             i.intermedCert.Subject,
+				Subject:            csr.Subject,
+				NotBefore:          time.Now(),
+				NotAfter:           i.certExpiry,
+				KeyUsage:           x509.KeyUsageDigitalSignature,
+				ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 			}
 
 			cert, err := x509.CreateCertificate(


### PR DESCRIPTION
Reverts GoogleCloudPlatform/alloydb-go-connector#401

We should continue to use pem CSR for `v1beta` endpoint. Planning to move to public key and `v1` endpoint soon.