### PR TITLE
chore: use CaCert from resp body

### DIFF
--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -119,7 +119,7 @@ func fetchEphemeralCert(
 		)
 	}
 
-	caCertPEMBlock, _ := pem.Decode([]byte(resp.PemCertificateChain[2]))
+	caCertPEMBlock, _ := pem.Decode([]byte(resp.CaCert))
 	if caCertPEMBlock == nil {
 		return nil, errtype.NewRefreshError(
 			"create ephemeral cert failed",

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -139,6 +139,7 @@ func CreateEphemeralSuccess(i FakeAlloyDBInstance, ct int) *Request {
 			pem.Encode(caPEM, &pem.Block{Type: "CERTIFICATE", Bytes: i.rootCACert.Raw})
 
 			rresp := alloydbpb.GenerateClientCertificateResponse{
+				CaCert:              caPEM.String(),
 				PemCertificateChain: []string{certPEM.String(), instancePEM.String(), caPEM.String()},
 			}
 			if err := json.NewEncoder(resp).Encode(&rresp); err != nil {


### PR DESCRIPTION
Instead of extracting the CA cert from `PemCertificateChain[2]` ourselves which is prone to potential errors in the future if the API changes, we should instead use the `CaCert` field of the response body and let the API handle the work of extracting it.