### PR TITLE
feat: add support for public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ language. Using an AlloyDB connector provides the following benefits:
 ## Installation
 
 You can install this repo with `go get`:
+
 ```sh
 go get cloud.google.com/go/alloydbconn
 ```
@@ -39,9 +40,11 @@ This package provides several functions for authorizing and encrypting
 connections. These functions can be used with your database driver to connect to
 your AlloyDB instance.
 
-AlloyDB supports network connectivity through private, internal IP addresses only. 
-This package must be run in an environment that is connected to the
-[VPC Network][vpc] that hosts your AlloyDB private IP address.
+AlloyDB supports network connectivity through public IP addresses and private,
+internal IP addresses. By default this package will attempt to connect over a
+private IP connection. When doing so, this package must be run in an
+environment that is connected to the [VPC Network][vpc] that hosts your
+AlloyDB private IP address.
 
 Please see [Configuring AlloyDB Connectivity][alloydb-connectivity] for more details.
 
@@ -52,12 +55,12 @@ Please see [Configuring AlloyDB Connectivity][alloydb-connectivity] for more det
 
 This package requires the following to connect successfully:
 
-- IAM principal (user, service account, etc.) with the [AlloyDB
+* IAM principal (user, service account, etc.) with the [AlloyDB
   Client and Service Usage Consumer][client-role] roles or equivalent
   permissions. [Credentials](#credentials) for the IAM principal are
   used to authorize connections to an AlloyDB instance.
 
-- The [AlloyDB Admin API][admin-api] to be enabled within your Google Cloud
+* The [AlloyDB Admin API][admin-api] to be enabled within your Google Cloud
   Project. By default, the API will be called in the project associated with the
   IAM principal.
 
@@ -136,14 +139,14 @@ For a full list of customizable behavior, see alloydbconn.Option.
 
 ### Using DialOptions
 
-If you want to customize things about how the connection is created, use
-`DialOption`:
+If you want to customize things about how the connection is created, such as
+connecting to AlloyDB over a public IP, use a `DialOption`:
 
 ```go
 conn, err := d.Dial(
     ctx,
     "projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>",
-    alloydbconn.WithTCPKeepAlive(30*time.Second),
+    alloydbconn.WithPublicIP(),
 )
 ```
 
@@ -154,7 +157,7 @@ be used by default:
 d, err := alloydbconn.NewDialer(
     ctx,
     alloydbconn.WithDefaultDialOptions(
-        alloydbconn.WithTCPKeepAlive(30*time.Second),
+        alloydbconn.WithPublicIP(),
     ),
 )
 ```

--- a/dialer.go
+++ b/dialer.go
@@ -30,8 +30,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
-	"cloud.google.com/go/alloydb/connectors/apiv1beta/connectorspb"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
+	"cloud.google.com/go/alloydb/connectors/apiv1alpha/connectorspb"
 	"cloud.google.com/go/alloydbconn/errtype"
 	"cloud.google.com/go/alloydbconn/internal/alloydb"
 	"cloud.google.com/go/alloydbconn/internal/trace"

--- a/dialer.go
+++ b/dialer.go
@@ -156,7 +156,7 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	}
 
 	dialCfg := dialCfg{
-		ipType: alloydb.PrivateIP,
+		ipType:       alloydb.PrivateIP,
 		tcpKeepAlive: defaultTCPKeepAlive,
 	}
 	for _, opt := range cfg.dialOpts {

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -341,7 +341,7 @@ type spyConnectionInfoCache struct {
 	connectionInfoCache
 }
 
-func (s *spyConnectionInfoCache) ConnectInfo(_ context.Context) (string, *tls.Config, error) {
+func (s *spyConnectionInfoCache) ConnectInfo(_ context.Context, _ string) (string, *tls.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	res := s.connectInfoCalls[s.connectInfoIndex]

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/errtype"
 	"cloud.google.com/go/alloydbconn/internal/alloydb"
 	"cloud.google.com/go/alloydbconn/internal/mock"

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -228,7 +228,6 @@ func TestAutoIAMAuthN(t *testing.T) {
 	t.Log(tt)
 }
 
-
 func TestPublicIP(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/errtype"
 	"golang.org/x/time/rate"
 )

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -193,13 +193,22 @@ func (i *Instance) Close() error {
 	return nil
 }
 
-// ConnectInfo returns an IP address of the AlloyDB instance.
-func (i *Instance) ConnectInfo(ctx context.Context) (string, *tls.Config, error) {
+// ConnectInfo returns an IP address specified by ipType (i.e., public or 
+// private) of the AlloyDB instance.
+func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls.Config, error) {
 	res, err := i.result(ctx)
 	if err != nil {
 		return "", nil, err
 	}
-	return res.result.instanceIPAddr, res.result.conf, nil
+	addr, ok = res.result.ipAddrs[ipType]
+	if !ok {
+		err := errtype.NewConfigError(
+			fmt.Sprintf("instance does not have IP of type %q", ipType),
+			i.instanceURI.String(),
+		)
+		return "", nil, err
+	}
+	return addr, res.result.conf, nil
 }
 
 // ForceRefresh triggers an immediate refresh operation to be scheduled and

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -200,6 +200,10 @@ func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls
 	if err != nil {
 		return "", nil, err
 	}
+	var (
+		addr string
+		ok   bool
+	)
 	addr, ok = res.result.ipAddrs[ipType]
 	if !ok {
 		err := errtype.NewConfigError(

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -193,7 +193,7 @@ func (i *Instance) Close() error {
 	return nil
 }
 
-// ConnectInfo returns an IP address specified by ipType (i.e., public or 
+// ConnectInfo returns an IP address specified by ipType (i.e., public or
 // private) of the AlloyDB instance.
 func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls.Config, error) {
 	res, err := i.result(ctx)

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/errtype"
 	"cloud.google.com/go/alloydbconn/internal/mock"
 	"golang.org/x/oauth2"

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -222,7 +221,7 @@ func TestClose(t *testing.T) {
 	i.Close()
 
 	_, _, err = i.ConnectInfo(ctx, PrivateIP)
-	if !strings.Contains(err.Error(), "context was canceled or expired") {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("failed to retrieve connect info: %v", err)
 	}
 }

--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -33,12 +33,16 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+const (
+	// PublicIP is the value for public IP connections.
+	PublicIP = "PUBLIC"
+	// PrivateIP is the value for private IP connections.
+	PrivateIP = "PRIVATE"
+)
+
 type connectInfo struct {
-	// ipAddr is the instance's IP addresses
-	ipAddr string
-	// publicIpAddress is the instance's public IP address. Will be an empty
-	// string if instance does not have public IP configured.
-	publicIpAddress string
+	// ipAddrs is the instance's IP addresses
+	ipAddrs map[string]string
 	// uid is the instance UID
 	uid string
 }
@@ -59,7 +63,23 @@ func fetchMetadata(ctx context.Context, cl *alloydbadmin.AlloyDBAdminClient, ins
 	if err != nil {
 		return connectInfo{}, errtype.NewRefreshError("failed to get instance metadata", inst.String(), err)
 	}
-	return connectInfo{ipAddr: resp.IpAddress, publicIpAddress: resp.GetPublicIpAddress(), uid: resp.InstanceUid}, nil
+
+	// parse any ip addresses that might be used to connect
+	ipAddrs := make(map[string]string)
+	if resp.GetIpAddress() != "" {
+		ipAddrs[PrivateIP] = resp.GetIpAddress()
+	}
+	if resp.GetPublicIpAddress() != "" {
+		ipAddrs[PublicIP] = resp.GetPublicIpAddress()
+	}
+
+	if len(ipAddrs) == 0 {
+		return connectInfo{}, errtype.NewConfigError(
+			"cannot connect to instance - it has no supported IP addresses",
+			inst.String(),
+		)
+	}
+	return connectInfo{ipAddrs: ipAddrs, uid: resp.InstanceUid}, nil
 }
 
 var errInvalidPEM = errors.New("certificate is not a valid PEM")
@@ -187,9 +207,9 @@ type refresher struct {
 }
 
 type refreshResult struct {
-	instanceIPAddr string
-	conf           *tls.Config
-	expiry         time.Time
+	ipAddrs map[string]string
+	conf    *tls.Config
+	expiry  time.Time
 }
 
 type certs struct {
@@ -257,9 +277,9 @@ func (r refresher) performRefresh(ctx context.Context, cn InstanceURI, k *rsa.Pr
 	c := &tls.Config{
 		Certificates: []tls.Certificate{cc.certChain},
 		RootCAs:      caCerts,
-		ServerName:   info.ipAddr,
+		ServerName:   info.ipAddrs[PrivateIP],
 		MinVersion:   tls.VersionTLS13,
 	}
 
-	return refreshResult{instanceIPAddr: info.ipAddr, conf: c, expiry: cc.expiry}, nil
+	return refreshResult{ipAddrs: info.ipAddrs, conf: c, expiry: cc.expiry}, nil
 }

--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
-	"cloud.google.com/go/alloydb/apiv1beta/alloydbpb"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
+	"cloud.google.com/go/alloydb/apiv1alpha/alloydbpb"
 	"cloud.google.com/go/alloydbconn/errtype"
 	"cloud.google.com/go/alloydbconn/internal/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -36,6 +36,9 @@ import (
 type connectInfo struct {
 	// ipAddr is the instance's IP addresses
 	ipAddr string
+	// publicIpAddress is the instance's public IP address. Will be an empty
+	// string if instance does not have public IP configured.
+	publicIpAddress string
 	// uid is the instance UID
 	uid string
 }
@@ -56,7 +59,7 @@ func fetchMetadata(ctx context.Context, cl *alloydbadmin.AlloyDBAdminClient, ins
 	if err != nil {
 		return connectInfo{}, errtype.NewRefreshError("failed to get instance metadata", inst.String(), err)
 	}
-	return connectInfo{ipAddr: resp.IpAddress, uid: resp.InstanceUid}, nil
+	return connectInfo{ipAddr: resp.IpAddress, publicIpAddress: resp.GetPublicIpAddress(), uid: resp.InstanceUid}, nil
 }
 
 var errInvalidPEM = errors.New("certificate is not a valid PEM")

--- a/internal/alloydb/refresh_test.go
+++ b/internal/alloydb/refresh_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/internal/mock"
 	"google.golang.org/api/option"
 )

--- a/internal/mock/alloydb.go
+++ b/internal/mock/alloydb.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/alloydb/connectors/apiv1beta/connectorspb"
+	"cloud.google.com/go/alloydb/connectors/apiv1alpha/connectorspb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/mock/alloydb.go
+++ b/internal/mock/alloydb.go
@@ -48,6 +48,7 @@ func WithPrivateIP(addr string) Option {
 		f.ipAddrs["PRIVATE"] = addr
 	}
 }
+
 // WithServerName sets the name that server uses to identify itself in the TLS
 // handshake.
 func WithServerName(name string) Option {

--- a/internal/mock/alloydb.go
+++ b/internal/mock/alloydb.go
@@ -35,13 +35,19 @@ import (
 // Option configures a FakeAlloyDBInstance
 type Option func(*FakeAlloyDBInstance)
 
-// WithIPAddr sets the IP address of the instance.
-func WithIPAddr(addr string) Option {
+// WithPublicIP sets the public IP address to addr.
+func WithPublicIP(addr string) Option {
 	return func(f *FakeAlloyDBInstance) {
-		f.ipAddr = addr
+		f.ipAddrs["PUBLIC"] = addr
 	}
 }
 
+// WithPrivateIP sets the private IP address to addr.
+func WithPrivateIP(addr string) Option {
+	return func(f *FakeAlloyDBInstance) {
+		f.ipAddrs["PRIVATE"] = addr
+	}
+}
 // WithServerName sets the name that server uses to identify itself in the TLS
 // handshake.
 func WithServerName(name string) Option {
@@ -63,8 +69,8 @@ type FakeAlloyDBInstance struct {
 	region  string
 	cluster string
 	name    string
-
-	ipAddr     string
+	// ipAddrs is a map of IP type (PUBLIC or PRIVATE) to IP address.
+	ipAddrs    map[string]string
 	uid        string
 	serverName string
 	certExpiry time.Time
@@ -100,7 +106,7 @@ func NewFakeInstance(proj, reg, clust, name string, opts ...Option) FakeAlloyDBI
 		region:     reg,
 		cluster:    clust,
 		name:       name,
-		ipAddr:     "127.0.0.1",
+		ipAddrs:    map[string]string{"PRIVATE": "127.0.0.1"},
 		uid:        "00000000-0000-0000-0000-000000000000",
 		serverName: "00000000-0000-0000-0000-000000000000.server.alloydb",
 		certExpiry: time.Now().Add(24 * time.Hour),

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -75,7 +75,7 @@ func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 			continue
 		}
 		if ipType == "PUBLIC" {
-			res["publicIpAddress"] = addr
+			res["PublicIpAddress"] = addr
 		}
 	}
 	res["instanceUid"] = i.uid

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -67,13 +67,29 @@ func (r *Request) matches(hR *http.Request) bool {
 func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 	p := fmt.Sprintf("/v1beta/projects/%s/locations/%s/clusters/%s/instances/%s/connectionInfo",
 		i.project, i.region, i.cluster, i.name)
+	
+	res := map[string]string{}
+	for ipType, addr := range i.ipAddrs {
+		if ipType == "PRIVATE" {
+			res["ipAddress"] = addr
+			continue
+		}
+		if ipType == "PUBLIC" {
+			res["publicIpAddress"] = addr
+		}
+	}
+	res["instanceUid"] = i.uid
+	jsonString, err := json.Marshal(res)
+	if err != nil {
+		panic(err)
+	}
 	return &Request{
 		reqMethod: http.MethodGet,
 		reqPath:   p,
 		reqCt:     ct,
 		handle: func(resp http.ResponseWriter, req *http.Request) {
 			resp.WriteHeader(http.StatusOK)
-			resp.Write([]byte(fmt.Sprintf(`{"ipAddress":"%s","instanceUid":"%s"}`, i.ipAddr, i.uid)))
+			resp.Write(jsonString)
 		},
 	}
 }

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/alloydb/apiv1beta/alloydbpb"
+	"cloud.google.com/go/alloydb/apiv1alpha/alloydbpb"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -67,7 +67,7 @@ func (r *Request) matches(hR *http.Request) bool {
 func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 	p := fmt.Sprintf("/v1beta/projects/%s/locations/%s/clusters/%s/instances/%s/connectionInfo",
 		i.project, i.region, i.cluster, i.name)
-	
+
 	res := map[string]string{}
 	for ipType, addr := range i.ipAddrs {
 		if ipType == "PRIVATE" {

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -75,7 +75,7 @@ func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 			continue
 		}
 		if ipType == "PUBLIC" {
-			res["PublicIpAddress"] = addr
+			res["publicIpAddress"] = addr
 		}
 	}
 	res["instanceUid"] = i.uid

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -67,13 +67,29 @@ func (r *Request) matches(hR *http.Request) bool {
 func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 	p := fmt.Sprintf("/v1beta/projects/%s/locations/%s/clusters/%s/instances/%s/connectionInfo",
 		i.project, i.region, i.cluster, i.name)
+
+	res := map[string]string{}
+	for ipType, addr := range i.ipAddrs {
+		if ipType == "PRIVATE" {
+			res["ipAddress"] = addr
+			continue
+		}
+		if ipType == "PUBLIC" {
+			res["publicIpAddress"] = addr
+		}
+	}
+	res["instanceUid"] = i.uid
+	jsonString, err := json.Marshal(res)
+	if err != nil {
+		panic(err)
+	}
 	return &Request{
 		reqMethod: http.MethodGet,
 		reqPath:   p,
 		reqCt:     ct,
 		handle: func(resp http.ResponseWriter, req *http.Request) {
 			resp.WriteHeader(http.StatusOK)
-			resp.Write([]byte(fmt.Sprintf(`{"ipAddress":"%s","instanceUid":"%s"}`, i.ipAddrs["PRIVATE"], i.uid)))
+			resp.Write(jsonString)
 		},
 	}
 }

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -67,29 +67,13 @@ func (r *Request) matches(hR *http.Request) bool {
 func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 	p := fmt.Sprintf("/v1beta/projects/%s/locations/%s/clusters/%s/instances/%s/connectionInfo",
 		i.project, i.region, i.cluster, i.name)
-
-	res := map[string]string{}
-	for ipType, addr := range i.ipAddrs {
-		if ipType == "PRIVATE" {
-			res["ipAddress"] = addr
-			continue
-		}
-		if ipType == "PUBLIC" {
-			res["publicIpAddress"] = addr
-		}
-	}
-	res["instanceUid"] = i.uid
-	jsonString, err := json.Marshal(res)
-	if err != nil {
-		panic(err)
-	}
 	return &Request{
 		reqMethod: http.MethodGet,
 		reqPath:   p,
 		reqCt:     ct,
 		handle: func(resp http.ResponseWriter, req *http.Request) {
 			resp.WriteHeader(http.StatusOK)
-			resp.Write(jsonString)
+			resp.Write([]byte(fmt.Sprintf(`{"ipAddress":"%s","instanceUid":"%s"}`, i.ipAddrs["PRIVATE"], i.uid)))
 		},
 	}
 }

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -65,7 +65,7 @@ func (r *Request) matches(hR *http.Request) bool {
 // InstanceGetSuccess returns a Request that responds to the `instance.get`
 // AlloyDB Admin API endpoint.
 func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
-	p := fmt.Sprintf("/v1beta/projects/%s/locations/%s/clusters/%s/instances/%s/connectionInfo",
+	p := fmt.Sprintf("/v1alpha/projects/%s/locations/%s/clusters/%s/instances/%s/connectionInfo",
 		i.project, i.region, i.cluster, i.name)
 
 	res := map[string]string{}
@@ -100,7 +100,7 @@ func CreateEphemeralSuccess(i FakeAlloyDBInstance, ct int) *Request {
 	return &Request{
 		reqMethod: http.MethodPost,
 		reqPath: fmt.Sprintf(
-			"/v1beta/projects/%s/locations/%s/clusters/%s:generateClientCertificate",
+			"/v1alpha/projects/%s/locations/%s/clusters/%s:generateClientCertificate",
 			i.project, i.region, i.cluster),
 		reqCt: ct,
 		handle: func(resp http.ResponseWriter, req *http.Request) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1beta"
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/internal/mock"
 	"go.opencensus.io/stats/view"
 	"google.golang.org/api/option"

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/alloydbconn/errtype"
+	"cloud.google.com/go/alloydbconn/internal/alloydb"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	apiopt "google.golang.org/api/option"
@@ -193,5 +194,19 @@ func WithOneOffDialFunc(dial func(ctx context.Context, network, addr string) (ne
 func WithTCPKeepAlive(d time.Duration) DialOption {
 	return func(cfg *dialCfg) {
 		cfg.tcpKeepAlive = d
+	}
+}
+
+// WithPublicIP returns a DialOption that specifies a public IP will be used to connect.
+func WithPublicIP() DialOption {
+	return func(cfg *dialCfg) {
+		cfg.ipType = alloydb.PublicIP
+	}
+}
+
+// WithPrivateIP returns a DialOption that specifies a private IP (VPC) will be used to connect.
+func WithPrivateIP() DialOption {
+	return func(cfg *dialCfg) {
+		cfg.ipType = alloydb.PrivateIP
 	}
 }

--- a/options.go
+++ b/options.go
@@ -167,6 +167,7 @@ type DialOption func(d *dialCfg)
 
 type dialCfg struct {
 	dialFunc     func(ctx context.Context, network, addr string) (net.Conn, error)
+	ipType       string
 	tcpKeepAlive time.Duration
 }
 


### PR DESCRIPTION
Add support for Public IP connections to AlloyDB instances via Go Connector. Default  option for `ipType` will be Private IP but users wishing to use Public IP can use the new `WithPublicIP()` DialOption.

PR Checklist:
- [X] use v1alpha client
- [X] allow multiple `ipAddr` to be returned
- [x] update existing unit tests
- [x] add new integration test
- [x] Update README with sample