### PR TITLE
docs: Use AlloyDB API for consistency with the official documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This package requires the following to connect successfully:
   permissions. [Credentials](#credentials) for the IAM principal are
   used to authorize connections to an AlloyDB instance.
 
-* The [AlloyDB Admin API][admin-api] to be enabled within your Google Cloud
+* The [AlloyDB API][admin-api] to be enabled within your Google Cloud
   Project. By default, the API will be called in the project associated with the
   IAM principal.
 


### PR DESCRIPTION
We received feedback from customers indicating confusion regarding the usage of `AlloyDB Admin API` in our documentation. To address this, we are updating the API reference to `AlloyDB API`, as recommended in the [official documentation](https://cloud.google.com/alloydb/docs/reference/rest).