### PR TITLE
fix: remove duplicate refresh for all connections

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -299,12 +299,6 @@ func invalidClientCert(c *tls.Config) bool {
 	// The following conditions should be impossible (no certs, nil leaf), but
 	// just in case there's an unknown edge case, check assumptions before
 	// proceeding.
-	if len(c.Certificates) == 0 {
-		return true
-	}
-	if c.Certificates[0].Leaf == nil {
-		return true
-	}
 	return time.Now().After(c.Certificates[0].Leaf.NotAfter)
 }
 

--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -160,7 +160,7 @@ func fetchEphemeralCert(
 		)
 	}
 
-	// Extract expiry
+	// Extract expiry from client certificate.
 	clientCertPEMBlock, _ := pem.Decode([]byte(resp.PemCertificateChain[0]))
 	if clientCertPEMBlock == nil {
 		return nil, errtype.NewRefreshError(
@@ -177,6 +177,9 @@ func fetchEphemeralCert(
 			err,
 		)
 	}
+	// Save the parsed certificate as the leaf certificate, to avoid additional
+	// parsing costs as part of the TLS connection.
+	cert.Leaf = clientCert
 
 	return &certs{
 		certChain: cert,

--- a/internal/alloydb/refresh_test.go
+++ b/internal/alloydb/refresh_test.go
@@ -83,6 +83,12 @@ func TestRefresh(t *testing.T) {
 	if got := res.expiry; wantExpiry != got {
 		t.Fatalf("expiry mismatch, want = %v, got = %v", wantExpiry, got)
 	}
+	if got, want := len(res.conf.Certificates), 1; got != want {
+		t.Fatalf("certificates should have length %v, got %v", want, got)
+	}
+	if got := res.conf.Certificates[0].Leaf; got == nil {
+		t.Fatal("leaf certificate should not be nil")
+	}
 }
 
 func TestRefreshFailsFast(t *testing.T) {


### PR DESCRIPTION
When we added a check to validate certificates on all new connections
[1], we also inadverantly caused each connection to trigger a duplicate
and blocking refresh operation with the following lines:

if c.Certificates[0].Leaf == nil {
	return true
}

When the tls.Config is created in refresh.go, it configures a client
certificate chain and adds the CA cert as a Root CA. However, the client
certificate chian is created with tls.X509KeyPair which explicitly
states:

"On successful return, Certificate.Leaf will be nil because the parsed
form of the certificate is not retained." [2]

As a result, the nil check above was always triggered and thereby
causing a duplicate refresh operation. An immediate fix to this
situation is to set the leaf certificate, which is what this commit
does. In fact, we're already parsing the leaf certificate to determine
its expiration and saving the parsed certificate has a performance
benefit:

[The Leaf certificate] may be initialized using x509.ParseCertificate to
reduce per-handshake processing. [3]

[1]: https://github.com/GoogleCloudPlatform/alloydb-go-connector/pull/456
[2]: https://pkg.go.dev/crypto/tls#X509KeyPair
[3]: https://pkg.go.dev/crypto/tls#Certificate.Leaf

Fixes #525