### PR TITLE
feat: add support for PSC

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,6 +85,7 @@ jobs:
             ALLOYDB_CLUSTER_PASS:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_CLUSTER_PASS
             ALLOYDB_INSTANCE_IP:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_INSTANCE_IP
             ALLOYDB_IAM_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_GO_IAM_USER
+            ALLOYDB_PSC_INSTANCE_URI:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_PSC_INSTANCE_URI
 
       - name: Run tests
         env:
@@ -94,6 +95,7 @@ jobs:
           ALLOYDB_PASS: '${{ steps.secrets.outputs.ALLOYDB_CLUSTER_PASS }}'
           ALLOYDB_INSTANCE_NAME: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_NAME }}'
           ALLOYDB_INSTANCE_IP: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_IP }}'
+          ALLOYDB_PSC_INSTANCE_URI: '${{ steps.secrets.outputs.ALLOYDB_PSC_INSTANCE_URI }}'
         # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -145,14 +145,25 @@ For a full list of customizable behavior, see alloydbconn.Option.
 
 ### Using DialOptions
 
-If you want to customize things about how the connection is created, such as
-connecting to AlloyDB over a public IP, use a `DialOption`:
+If you want to customize how the connection is created, use a DialOption.
+
+For example, to connect over public IP, use:
 
 ```go
 conn, err := d.Dial(
     ctx,
     "projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>",
     alloydbconn.WithPublicIP(),
+)
+```
+
+Or to use PSC, use:
+
+``` go
+conn, err := d.Dial(
+    ctx,
+    "projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>",
+    alloydbconn.WithPSC(),
 )
 ```
 
@@ -184,11 +195,11 @@ import (
     "database/sql"
 
     "cloud.google.com/go/alloydbconn"
-    "cloud.google.com/go/alloydbconn/driver/pgxv4"
+    "cloud.google.com/go/alloydbconn/driver/pgxv5"
 )
 
 func Connect() {
-    cleanup, err := pgxv4.RegisterDriver("alloydb")
+    cleanup, err := pgxv5.RegisterDriver("alloydb", alloydbconn.WithPublicIP())
     if err != nil {
         // ... handle error
     }

--- a/database_sql_public_ip_test.go
+++ b/database_sql_public_ip_test.go
@@ -14,7 +14,6 @@
 
 package alloydbconn_test
 
-// [START alloydb_databasesql_connect_connector_public_ip]
 import (
 	"database/sql"
 	"fmt"
@@ -73,5 +72,3 @@ func connectDatabaseSQLWithPublicIP(
 	)
 	return db, cleanup, err
 }
-
-// [END alloydb_databasesql_connect_connector_public_ip]

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -129,9 +129,11 @@ func TestConnectionInfo(t *testing.T) {
 	ctx := context.Background()
 
 	wantAddr := "0.0.0.0"
+	wantPSC := "x.y.alloydb.goog"
 	inst := mock.NewFakeInstance(
 		"my-project", "my-region", "my-cluster", "my-instance",
 		mock.WithPrivateIP(wantAddr),
+		mock.WithPSC(wantPSC),
 	)
 	mc, url, cleanup := mock.HTTPClient(
 		mock.InstanceGetSuccess(inst, 1),
@@ -173,6 +175,20 @@ func TestConnectionInfo(t *testing.T) {
 			wantAddr, gotAddr,
 		)
 	}
+
+	ci, err = i.ConnectionInfo(ctx)
+	if err != nil {
+		t.Fatalf("failed to retrieve connect info: %v", err)
+	}
+
+	gotAddr = ci.IPAddrs[PSC]
+	if gotAddr != wantPSC {
+		t.Fatalf(
+			"ConnectInfo returned unexpected IP address, want = %v, got = %v",
+			wantPSC, gotAddr,
+		)
+	}
+
 }
 
 func testInstanceURI() InstanceURI {

--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -38,6 +38,8 @@ const (
 	PublicIP = "PUBLIC"
 	// PrivateIP is the value for private IP connections.
 	PrivateIP = "PRIVATE"
+	// PSC designates PSC-based connections.
+	PSC = "PSC"
 )
 
 type instanceInfo struct {
@@ -71,11 +73,14 @@ func fetchInstanceInfo(
 
 	// parse any ip addresses that might be used to connect
 	ipAddrs := make(map[string]string)
-	if resp.GetIpAddress() != "" {
-		ipAddrs[PrivateIP] = resp.GetIpAddress()
+	if addr := resp.GetIpAddress(); addr != "" {
+		ipAddrs[PrivateIP] = addr
 	}
-	if resp.GetPublicIpAddress() != "" {
-		ipAddrs[PublicIP] = resp.GetPublicIpAddress()
+	if addr := resp.GetPublicIpAddress(); addr != "" {
+		ipAddrs[PublicIP] = addr
+	}
+	if addr := resp.GetPscDnsName(); addr != "" {
+		ipAddrs[PSC] = addr
 	}
 
 	if len(ipAddrs) == 0 {

--- a/internal/alloydb/refresh_test.go
+++ b/internal/alloydb/refresh_test.go
@@ -30,6 +30,7 @@ const testDialerID = "some-dialer-id"
 func TestRefresh(t *testing.T) {
 	wantPrivateIP := "10.0.0.1"
 	wantPublicIP := "127.0.0.1"
+	wantPSC := "x.y.alloydb.goog"
 	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
 	wantInstURI := "/projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"
 	cn, err := ParseInstURI(wantInstURI)
@@ -40,6 +41,7 @@ func TestRefresh(t *testing.T) {
 		"my-project", "my-region", "my-cluster", "my-instance",
 		mock.WithPrivateIP(wantPrivateIP),
 		mock.WithPublicIP(wantPublicIP),
+		mock.WithPSC(wantPSC),
 		mock.WithCertExpiry(wantExpiry),
 	)
 	mc, url, cleanup := mock.HTTPClient(
@@ -81,7 +83,14 @@ func TestRefresh(t *testing.T) {
 		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPublicIP, gotIP)
 	}
 	if got := res.Expiration; wantExpiry != got {
-		t.Fatalf("expiry mismatch, want = %v, got = %v", wantExpiry, got)
+		t.Fatalf("expiration mismatch, want = %v, got = %v", wantExpiry, got)
+	}
+	gotPSC, ok := res.IPAddrs[PSC]
+	if !ok {
+		t.Fatal("metadata IP addresses did not include PSC address")
+	}
+	if wantPSC != gotPSC {
+		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPSC, gotPSC)
 	}
 	if got := res.ClientCert.Leaf; got == nil {
 		t.Fatal("leaf certificate should not be nil")

--- a/internal/mock/alloydb.go
+++ b/internal/mock/alloydb.go
@@ -49,6 +49,13 @@ func WithPrivateIP(addr string) Option {
 	}
 }
 
+// WithPSC sets the PSC address to addr.
+func WithPSC(addr string) Option {
+	return func(f *FakeAlloyDBInstance) {
+		f.ipAddrs["PSC"] = addr
+	}
+}
+
 // WithServerName sets the name that server uses to identify itself in the TLS
 // handshake.
 func WithServerName(name string) Option {
@@ -217,7 +224,7 @@ func StartServerProxy(t *testing.T, inst FakeAlloyDBInstance) func() {
 						Leaf:        inst.serverCert,
 					},
 				},
-				ServerName: "FIXME", // FIXME: this will become the instance UID
+				ServerName: "127.0.0.1",
 				ClientAuth: tls.RequireAndVerifyClientCert,
 				ClientCAs:  pool,
 			})

--- a/internal/mock/alloydbadmin.go
+++ b/internal/mock/alloydbadmin.go
@@ -77,6 +77,9 @@ func InstanceGetSuccess(i FakeAlloyDBInstance, ct int) *Request {
 		if ipType == "PUBLIC" {
 			res["publicIpAddress"] = addr
 		}
+		if ipType == "PSC" {
+			res["psc_dns_name"] = addr
+		}
 	}
 	res["instanceUid"] = i.uid
 	jsonString, err := json.Marshal(res)

--- a/options.go
+++ b/options.go
@@ -1,11 +1,11 @@
 // Copyright 2020 Google LLC
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -113,7 +113,8 @@ func WithTokenSource(s oauth2.TokenSource) Option {
 	}
 }
 
-// WithRSAKey returns an Option that specifies a rsa.PrivateKey used to represent the client.
+// WithRSAKey returns an Option that specifies a rsa.PrivateKey used to
+// represent the client.
 func WithRSAKey(k *rsa.PrivateKey) Option {
 	return func(d *dialerConfig) {
 		d.rsaKey = k
@@ -156,8 +157,8 @@ func WithDialFunc(dial func(ctx context.Context, network, addr string) (net.Conn
 }
 
 // WithIAMAuthN enables automatic IAM Authentication. If no token source has
-// been configured (such as with WithTokenSource, WithCredentialsFile, etc), the
-// dialer will use the default token source as defined by
+// been configured (such as with WithTokenSource, WithCredentialsFile, etc),
+// the dialer will use the default token source as defined by
 // https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentialsWithParams.
 func WithIAMAuthN() Option {
 	return func(d *dialerConfig) {
@@ -173,7 +174,8 @@ func WithDebugLogger(l debug.Logger) Option {
 	}
 }
 
-// A DialOption is an option for configuring how a Dialer's Dial call is executed.
+// A DialOption is an option for configuring how a Dialer's Dial call is
+// executed.
 type DialOption func(d *dialCfg)
 
 type dialCfg struct {
@@ -200,23 +202,34 @@ func WithOneOffDialFunc(dial func(ctx context.Context, network, addr string) (ne
 	}
 }
 
-// WithTCPKeepAlive returns a DialOption that specifies the tcp keep alive period for the connection returned by Dial.
+// WithTCPKeepAlive returns a DialOption that specifies the tcp keep alive
+// period for the connection returned by Dial.
 func WithTCPKeepAlive(d time.Duration) DialOption {
 	return func(cfg *dialCfg) {
 		cfg.tcpKeepAlive = d
 	}
 }
 
-// WithPublicIP returns a DialOption that specifies a public IP will be used to connect.
+// WithPublicIP returns a DialOption that specifies a public IP will be used to
+// connect.
 func WithPublicIP() DialOption {
 	return func(cfg *dialCfg) {
 		cfg.ipType = alloydb.PublicIP
 	}
 }
 
-// WithPrivateIP returns a DialOption that specifies a private IP (VPC) will be used to connect.
+// WithPrivateIP returns a DialOption that specifies a private IP (VPC) will be
+// used to connect.
 func WithPrivateIP() DialOption {
 	return func(cfg *dialCfg) {
 		cfg.ipType = alloydb.PrivateIP
+	}
+}
+
+// WithPSC returns a DialOption that specifies a PSC endpoint will be used to
+// connect.
+func WithPSC() DialOption {
+	return func(cfg *dialCfg) {
+		cfg.ipType = alloydb.PSC
 	}
 }

--- a/pgxpool_psc_test.go
+++ b/pgxpool_psc_test.go
@@ -23,13 +23,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// connectPgxWithPublicIP establishes a connection to your database using
-// pgxpool and the AlloyDB Go Connector (aka alloydbconn.Dialer)
+// connectPgxWithPSC establishes a connection to your database using pgxpool
+// and the AlloyDB Go Connector (aka alloydbconn.Dialer)
 //
 // The function takes an instance URI, a username, a password, and a database
 // name. Usage looks like this:
 //
-//	pool, cleanup, err := connectPgxWithPublicIP(
+//	pool, cleanup, err := connectPgxWithPSC(
 //	  context.Background(),
 //	  "projects/myproject/locations/us-central1/clusters/mycluster/instances/myinstance",
 //	  "postgres",
@@ -39,7 +39,7 @@ import (
 //
 // In addition to a *pgxpool.Pool type, the function returns a cleanup function
 // that should be called when you're done with the database connection.
-func connectPgxWithPublicIP(
+func connectPgxWithPSC(
 	ctx context.Context, instURI, user, pass, dbname string,
 ) (*pgxpool.Pool, func() error, error) {
 	// First initialize the dialer. alloydbconn.NewDialer accepts additional
@@ -74,7 +74,7 @@ func connectPgxWithPublicIP(
 
 	// Tell pgx to use alloydbconn.Dialer to connect to the instance.
 	config.ConnConfig.DialFunc = func(ctx context.Context, _ string, _ string) (net.Conn, error) {
-		return d.Dial(ctx, instURI, alloydbconn.WithPublicIP())
+		return d.Dial(ctx, instURI, alloydbconn.WithPSC())
 	}
 
 	// Establish the connection.


### PR DESCRIPTION
This commit adds support for dialing a PSC endpoint with the Go Connector. Callers should provide the WithPSC DialOption to dial calls to send all traffic to the PSC endpoint.