### PR TITLE
fix: return a friendly error if the dialer is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ d, err := alloydbconn.NewDialer(ctx)
 if err != nil {
     log.Fatalf("failed to initialize dialer: %v", err)
 }
+// Don't close the dialer until you're done with the database connection
+// e.g. at the end of your main function
 defer d.Close()
 
 // Tell the driver to use the AlloyDB Go Connector to create connections

--- a/database_sql_public_ip_test.go
+++ b/database_sql_public_ip_test.go
@@ -62,7 +62,7 @@ func connectDatabaseSQLWithPublicIP(
 	}
 
 	db, err := sql.Open(
-		"alloydb",
+		"alloydb-public",
 		fmt.Sprintf(
 			// sslmode is disabled, because the Dialer will handle the SSL
 			// connection instead.


### PR DESCRIPTION
If the dialer has already been closed, return a clear error.

Fixes #522