### PR TITLE
chore: fix govulncheck.yaml

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -37,5 +37,10 @@ jobs:
         with:
           go-version: "1.22"
           check-latest: true
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0 # v1


### PR DESCRIPTION
The workflow wasn't checking out the SHA of the PR. This commit corrects the error.