### PR TITLE
refactor: shrink connectionInfoCache interface

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -247,7 +247,9 @@ func TestDialerRemovesInvalidInstancesFromCache(t *testing.T) {
 			err: errors.New("connect info failed"),
 		}},
 	}
-	d.instances[badInst] = spy
+	d.cache[badInst] = monitoredCache{
+		connectionInfoCache: spy,
+	}
 
 	_, err = d.Dial(context.Background(), badInstanceName)
 	if err == nil {
@@ -261,7 +263,7 @@ func TestDialerRemovesInvalidInstancesFromCache(t *testing.T) {
 
 	// Now verify that bad connection name has been deleted from map.
 	d.lock.RLock()
-	_, ok := d.instances[badInst]
+	_, ok := d.cache[badInst]
 	d.lock.RUnlock()
 	if ok {
 		t.Fatal("bad instance was not removed from the cache")
@@ -297,7 +299,9 @@ func TestDialRefreshesExpiredCertificates(t *testing.T) {
 			},
 		},
 	}
-	d.instances[cn] = spy
+	d.cache[cn] = monitoredCache{
+		connectionInfoCache: spy,
+	}
 
 	_, err = d.Dial(context.Background(), inst)
 	if !errors.Is(err, sentinel) {
@@ -317,7 +321,7 @@ func TestDialRefreshesExpiredCertificates(t *testing.T) {
 
 	// Now verify that bad connection name has been deleted from map.
 	d.lock.RLock()
-	_, ok := d.instances[cn]
+	_, ok := d.cache[cn]
 	d.lock.RUnlock()
 	if ok {
 		t.Fatal("bad instance was not removed from the cache")

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -127,9 +127,6 @@ func (r *refreshOperation) isValid() bool {
 // required information approximately 4 minutes before the previous certificate
 // expires (every ~56 minutes).
 type RefreshAheadCache struct {
-	// OpenConns is the number of open connections to the instance.
-	openConns uint64
-
 	instanceURI InstanceURI
 	logger      debug.Logger
 	key         *rsa.PrivateKey
@@ -183,11 +180,6 @@ func NewRefreshAheadCache(
 	i.next = i.cur
 	i.resultGuard.Unlock()
 	return i
-}
-
-// OpenConns reports the number of open connections.
-func (i *RefreshAheadCache) OpenConns() *uint64 {
-	return &i.openConns
 }
 
 // Close closes the instance; it stops the refresh cycle and prevents it from


### PR DESCRIPTION
This commit moves connection tracking to the dialer and reduces the size of the connectionInfoCache interface. This change makes it easier to implement alternate caches (e.g., a lazy refresh cache). In addition, this commit renames some variables to match the new names.