### PR TITLE
feat: add context debug logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ func main() {
 
 The Go Connector supports optional debug logging to help diagnose problems with
 the background certificate refresh. To enable it, provide a logger that
-implements the `debug.Logger` interface when initializing the Dialer.
+implements the `debug.ContextLogger` interface when initializing the Dialer.
 
 For example:
 
@@ -326,7 +326,7 @@ import (
 
 type myLogger struct{}
 
-func (l *myLogger) Debugf(format string, args ...interface{}) {
+func (l *myLogger) Debugf(ctx context.Context, format string, args ...interface{}) {
     // Log as you like here
 }
 
@@ -335,7 +335,7 @@ func connect() {
 
     d, err := NewDialer(
         context.Background(),
-        alloydbconn.WithDebugLogger(l),
+        alloydbconn.WithContextDebugLogger(l),
     )
     // use dialer as usual...
 }

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -14,8 +14,17 @@
 
 package debug
 
+import "context"
+
 // Logger is the interface used for debug logging. By default, it is unused.
 type Logger interface {
 	// Debugf is for reporting information about internal operations.
 	Debugf(format string, args ...interface{})
+}
+
+// ContextLogger is the interface used for debug logging. By default, it is
+// unused.
+type ContextLogger interface {
+	// Debugf is for reporting information about internal operations.
+	Debugf(ctx context.Context, format string, args ...interface{})
 }

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -31,7 +31,7 @@ import (
 
 type nullLogger struct{}
 
-func (nullLogger) Debugf(string, ...interface{}) {}
+func (nullLogger) Debugf(context.Context, string, ...interface{}) {}
 
 // genRSAKey generates an RSA key used for test.
 func genRSAKey() *rsa.PrivateKey {

--- a/internal/alloydb/static.go
+++ b/internal/alloydb/static.go
@@ -78,7 +78,7 @@ func (s *staticData) UnmarshalJSON(data []byte) error {
 
 // StaticConnectionInfoCache provides connection info that is never refreshed.
 type StaticConnectionInfoCache struct {
-	logger debug.Logger
+	logger debug.ContextLogger
 	info   ConnectionInfo
 }
 
@@ -86,7 +86,7 @@ type StaticConnectionInfoCache struct {
 // always return the predefined connection info within the provided io.Reader
 func NewStaticConnectionInfoCache(
 	inst InstanceURI,
-	l debug.Logger,
+	l debug.ContextLogger,
 	r io.Reader,
 ) (*StaticConnectionInfoCache, error) {
 	data, err := io.ReadAll(r)


### PR DESCRIPTION
Callers may now provide a context to correlate logs with trace IDs in their implementation of the interface.

This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/797