### PR TITLE
chore: correct renovate's go grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
     },
     {
       "groupName": "Non-major dependency updates",
-      "matchLanguages": ["go"],
+      "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"],
     },
   ]


### PR DESCRIPTION
matchManagers works as see in the AlloyDB Auth Proxy.