### PR TITLE
fix: rely on the PSC DNS name instead of the private IP address

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -333,25 +333,13 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		}
 	}
 
-	// TODO: use the correct addr as server name once PSC DNS is populated
-	// in all existing clusters. When that happens, delete this if statement.
-	serverName := addr
-	if cfg.ipType == alloydb.PSC {
-		serverName, ok = ci.IPAddrs[alloydb.PrivateIP]
-		if !ok {
-			// This shouldn't happen, but be prudent regardless.
-			return nil, errtype.NewDialError(
-				"failed to lookup server name", inst.String(), nil,
-			)
-		}
-	}
 	c := &tls.Config{
 		Certificates: []tls.Certificate{ci.ClientCert},
 		RootCAs:      ci.RootCAs,
 		// The PSC, private, and public IP all appear in the certificate as
 		// SAN. Use the server name that corresponds to the requested
 		// connection path.
-		ServerName: serverName,
+		ServerName: addr,
 		MinVersion: tls.VersionTLS13,
 	}
 	tlsConn := tls.Client(conn, c)


### PR DESCRIPTION
The PSC DNS name is included in all existing server certificates. So now we can use the PSC DNS name to verify the certificate instead of the private IP address of the instance. Users of PSC-enabled clusters won't have access to the private IP address anyway.

Fixes #546 