### PR TITLE
chore: skip integration tests on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,8 +28,14 @@ permissions: read-all
 
 jobs:
   integration:
-    # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
+    # run job on proper workflow event triggers (skip job for pull_request
+    # event from forks and only run pull_request_target for "tests: run" label)
     runs-on: [self-hosted, linux, x64]
+    # run integration tests on all builds except pull requests from forks or
+    # dependabot
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     name: "integration tests (linux)"
     permissions:
       contents: 'read'
@@ -139,50 +145,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - id: 'auth'
-        name: Authenticate to Google Cloud
-        # only needed for Flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
-        uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
-        with:
-          workload_identity_provider: ${{ vars.PROVIDER_NAME }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
-
       - name: Run tests
         if: matrix.goarch == ''
-        # specifying bash shell ensures a failure in a piped process isn't lost by using `set -eo pipefail`
-        shell: bash
         run: |
-          go test -v -race -cover -short ./... | tee test_results.txt
+          go test -v -race -cover -short ./...
       - name: Run tests (386)
         # 386 archs don't support race detector
         if: matrix.goarch == '386'
         run: |
           go test -v -cover -short ./...
-
-      - name: Convert test output to XML
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && always() && matrix.goarch == '' }}
-        run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
-          go-junit-report -in test_results.txt -set-exit-code -out unit_sponge_log.xml
-
-      - name: FlakyBot (Linux)
-        # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
-        run: |
-          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
-          chmod +x ./flakybot
-          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      - name: FlakyBot (Windows)
-        # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
-        run: |
-          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
-          ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      - name: FlakyBot (macOS)
-        # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'macOS' && always() }}
-        run: |
-          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot-darwin-amd64 -o flakybot -s -L
-          chmod +x ./flakybot
-          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,8 +28,6 @@ permissions: read-all
 
 jobs:
   integration:
-    # run job on proper workflow event triggers (skip job for pull_request
-    # event from forks and only run pull_request_target for "tests: run" label)
     runs-on: [self-hosted, linux, x64]
     # run integration tests on all builds except pull requests from forks or
     # dependabot


### PR DESCRIPTION
GitHub provides no reasonable and secure way to run integration tests against PRs from forks. This PR adjusts the CI builds to skip integration tests on PRs from forks and otherwise runs the entire test suite for internal PRs. In addition, integration tests will run on main regardless to catch any regressions.