### PR TITLE
chore: add option for connection check opt-out

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -49,6 +49,27 @@ func (stubTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{}, nil
 }
 
+func TestDialerIncompatibleOptions(t *testing.T) {
+	tcs := []struct {
+		desc string
+		opts []Option
+	}{
+		{
+			desc: "opt out connection check doesn't work with IAM authn",
+			opts: []Option{WithOptOutOfAdvancedConnectionCheck(), WithIAMAuthN()},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := NewDialer(context.Background(), tc.opts...)
+			if err == nil {
+				t.Fatalf("got = %v, want no error", err)
+			}
+		})
+	}
+}
+
 func TestDialerCanConnectToInstance(t *testing.T) {
 	ctx := context.Background()
 	inst := mock.NewFakeInstance(

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -106,6 +106,16 @@ func TestPgxConnect(t *testing.T) {
 				)
 			},
 		},
+		{
+			desc: "metadata exchange disabled",
+			f: func(ctx context.Context) (*pgxpool.Pool, func() error, error) {
+				return connectPgx(
+					ctx, alloydbInstanceName,
+					alloydbUser, alloydbPass, alloydbDB,
+					alloydbconn.WithOptOutOfAdvancedConnectionCheck(),
+				)
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -169,13 +169,14 @@ func NewRefreshAheadCache(
 	key *rsa.PrivateKey,
 	refreshTimeout time.Duration,
 	dialerID string,
+	disableMetadataExchange bool,
 ) *RefreshAheadCache {
 	ctx, cancel := context.WithCancel(context.Background())
 	i := &RefreshAheadCache{
 		instanceURI:    instance,
 		logger:         l,
 		l:              rate.NewLimiter(rate.Every(refreshInterval), refreshBurst),
-		r:              newAdminAPIClient(client, key, dialerID),
+		r:              newAdminAPIClient(client, key, dialerID, disableMetadataExchange),
 		refreshTimeout: refreshTimeout,
 		ctx:            ctx,
 		cancel:         cancel,

--- a/internal/alloydb/instance_test.go
+++ b/internal/alloydb/instance_test.go
@@ -158,6 +158,7 @@ func TestConnectionInfo(t *testing.T) {
 		testInstanceURI(),
 		nullLogger{},
 		c, rsaKey, 30*time.Second, "dialer-id",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("failed to create mock instance: %v", err)
@@ -210,6 +211,7 @@ func TestConnectInfoErrors(t *testing.T) {
 		testInstanceURI(),
 		nullLogger{},
 		c, rsaKey, 0, "dialer-id",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize Instance: %v", err)
@@ -243,6 +245,7 @@ func TestClose(t *testing.T) {
 		testInstanceURI(),
 		nullLogger{},
 		c, rsaKey, 30, "dialer-ider",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize Instance: %v", err)

--- a/internal/alloydb/lazy.go
+++ b/internal/alloydb/lazy.go
@@ -43,15 +43,12 @@ func NewLazyRefreshCache(
 	key *rsa.PrivateKey,
 	_ time.Duration,
 	dialerID string,
+	disableMetadataExchange bool,
 ) *LazyRefreshCache {
 	return &LazyRefreshCache{
 		uri:    uri,
 		logger: l,
-		r: newAdminAPIClient(
-			client,
-			key,
-			dialerID,
-		),
+		r:      newAdminAPIClient(client, key, dialerID, disableMetadataExchange),
 	}
 }
 

--- a/internal/alloydb/lazy_test.go
+++ b/internal/alloydb/lazy_test.go
@@ -49,6 +49,7 @@ func TestLazyRefreshCacheConnectionInfo(t *testing.T) {
 	cache := NewLazyRefreshCache(
 		testInstanceURI(), nullLogger{}, c,
 		rsaKey, 30*time.Second, "",
+		false,
 	)
 
 	ci, err := cache.ConnectionInfo(context.Background())
@@ -91,6 +92,7 @@ func TestLazyRefreshCacheForceRefresh(t *testing.T) {
 	cache := NewLazyRefreshCache(
 		testInstanceURI(), nullLogger{}, c,
 		rsaKey, 30*time.Second, "",
+		false,
 	)
 
 	_, err = cache.ConnectionInfo(context.Background())

--- a/internal/alloydb/refresh_test.go
+++ b/internal/alloydb/refresh_test.go
@@ -62,7 +62,7 @@ func TestRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("admin API client error: %v", err)
 	}
-	r := newAdminAPIClient(cl, rsaKey, testDialerID)
+	r := newAdminAPIClient(cl, rsaKey, testDialerID, false)
 	res, err := r.connectionInfo(context.Background(), cn)
 	if err != nil {
 		t.Fatalf("performRefresh unexpectedly failed with error: %v", err)
@@ -124,7 +124,7 @@ func TestRefreshFailsFast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("admin API client error: %v", err)
 	}
-	r := newAdminAPIClient(cl, rsaKey, testDialerID)
+	r := newAdminAPIClient(cl, rsaKey, testDialerID, false)
 
 	_, err = r.connectionInfo(context.Background(), cn)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -49,6 +49,10 @@ type dialerConfig struct {
 	logger         debug.ContextLogger
 	lazyRefresh    bool
 
+	// disableMetadataExchange is a temporary addition and will be removed in
+	// future versions.
+	disableMetadataExchange bool
+
 	staticConnInfo io.Reader
 	// err tracks any dialer options that may have failed.
 	err error
@@ -238,6 +242,24 @@ func WithLazyRefresh() Option {
 func WithStaticConnectionInfo(r io.Reader) Option {
 	return func(d *dialerConfig) {
 		d.staticConnInfo = r
+	}
+}
+
+// WithOptOutOfAdvancedConnectionCheck disables the dataplane permission check.
+// It is intended only for clients who are running in an environment where the
+// workload's IP address is otherwise unknown and cannot be allow-listed in a
+// VPC Service Control security perimeter. This option is incompatible with IAM
+// Authentication.
+//
+// NOTE: This option is for internal usage only and is meant to ease the
+// migration when the advanced check will be required on the server. In future
+// versions this will revert to a no-op and should not be used. If you think
+// you need this option, open an issue on
+// https://github.com/GoogleCloudPlatform/alloydb-go-connector for design
+// advice.
+func WithOptOutOfAdvancedConnectionCheck() Option {
+	return func(d *dialerConfig) {
+		d.disableMetadataExchange = true
 	}
 }
 

--- a/pgxpool_test.go
+++ b/pgxpool_test.go
@@ -42,13 +42,14 @@ import (
 // that should be called when you're done with the database connection.
 func connectPgx(
 	ctx context.Context, instURI, user, pass, dbname string,
+	opts ...alloydbconn.Option,
 ) (*pgxpool.Pool, func() error, error) {
 	// First initialize the dialer. alloydbconn.NewDialer accepts additional
 	// options to configure credentials, timeouts, etc.
 	//
 	// For details, see:
 	// https://pkg.go.dev/cloud.google.com/go/alloydbconn#Option
-	d, err := alloydbconn.NewDialer(ctx)
+	d, err := alloydbconn.NewDialer(ctx, opts...)
 	if err != nil {
 		noop := func() error { return nil }
 		return nil, noop, fmt.Errorf("failed to init Dialer: %v", err)


### PR DESCRIPTION
This commit adds an option (marked for internal usage only) that will allow clients to disable the metadata exchange. Future versions will make this option a no-op once all internal consumers are able to use the metadata exchange without incompatible behavior with VPC-SC.