### PR TITLE
feat: add bytes_sent and bytes_received as metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ Supported metrics include:
   refresh operations
 - `alloydbconn/refresh_failure_count`: The number of failed refresh
   operations.
+- `alloydbconn/bytes_sent`: The number of bytes sent to an AlloyDB instance.
+- `alloydbconn/bytes_received`: The number of bytes received from an AlloyDB
+  instance.
 
 Supported traces include:
 

--- a/internal/trace/metrics.go
+++ b/internal/trace/metrics.go
@@ -57,6 +57,16 @@ var (
 		"A failed certificate refresh operation",
 		stats.UnitDimensionless,
 	)
+	mBytesSent = stats.Int64(
+		"alloydbconn/bytes_sent",
+		"The bytes sent to an AlloyDB instance",
+		stats.UnitDimensionless,
+	)
+	mBytesReceived = stats.Int64(
+		"alloydbconn/bytes_received",
+		"The bytes received from an AlloyDB instance",
+		stats.UnitDimensionless,
+	)
 
 	latencyView = &view.View{
 		Name:        "alloydbconn/dial_latency",
@@ -94,6 +104,20 @@ var (
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{keyInstance, keyDialerID, keyErrorCode},
 	}
+	bytesSentView = &view.View{
+		Name:        "alloydbconn/bytes_sent",
+		Measure:     mBytesSent,
+		Description: "The number of bytes sent to an AlloyDB instance",
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{keyInstance, keyDialerID},
+	}
+	bytesReceivedView = &view.View{
+		Name:        "alloydbconn/bytes_received",
+		Measure:     mBytesReceived,
+		Description: "The number of bytes received from an AlloyDB instance",
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{keyInstance, keyDialerID},
+	}
 
 	registerOnce sync.Once
 	registerErr  error
@@ -110,6 +134,8 @@ func InitMetrics() error {
 			dialFailureView,
 			refreshCountView,
 			failedRefreshCountView,
+			bytesSentView,
+			bytesReceivedView,
 		); rErr != nil {
 			registerErr = fmt.Errorf("failed to initialize metrics: %v", rErr)
 		}
@@ -155,6 +181,18 @@ func RecordRefreshResult(ctx context.Context, instance, dialerID string, err err
 		return
 	}
 	stats.Record(ctx, mSuccessfulRefresh.M(1))
+}
+
+// RecordBytesSent reports the number of bytes sent to an AlloyDB instance.
+func RecordBytesSent(ctx context.Context, num int64, instance, dialerID string) {
+	ctx, _ = tag.New(ctx, tag.Upsert(keyInstance, instance), tag.Upsert(keyDialerID, dialerID))
+	stats.Record(ctx, mBytesSent.M(num))
+}
+
+// RecordBytesReceived reports the number of bytes received from an AlloyDB instance.
+func RecordBytesReceived(ctx context.Context, num int64, instance, dialerID string) {
+	ctx, _ = tag.New(ctx, tag.Upsert(keyInstance, instance), tag.Upsert(keyDialerID, dialerID))
+	stats.Record(ctx, mBytesReceived.M(num))
 }
 
 // errorCode returns an error code as given from the AlloyDB Admin API, provided

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -188,13 +188,15 @@ func TestDialerWithMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buf.WriteByte failed: %v", err)
 	}
-	_, err = conn2.Write(buf.Bytes())
-	if err != nil {
-		t.Fatalf("conn.Write failed: %v", err)
-	}
+	// Doing a read before doing a write, because when this unit test runs on
+	// Windows, it fails when the write is done before the read.
 	_, err = conn2.Read(buf.Bytes())
 	if err != nil {
 		t.Fatalf("conn.Read failed: %v", err)
+	}
+	_, err = conn2.Write(buf.Bytes())
+	if err != nil {
+		t.Fatalf("conn.Write failed: %v", err)
 	}
 	defer conn2.Close()
 	// dial a bogus instance

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -14,6 +14,7 @@
 package alloydbconn
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -118,6 +119,24 @@ func wantCountMetric(t *testing.T, wantName string, ms []metric) {
 	)
 }
 
+// wantSumMetric ensures the provided metrics include a metric with the wanted
+// name and at least one data point.
+func wantSumMetric(t *testing.T, wantName string, ms []metric) {
+	t.Helper()
+	gotNames := make(map[string]view.AggregationData)
+	for _, m := range ms {
+		gotNames[m.name] = m.data
+		_, ok := m.data.(*view.SumData)
+		if m.name == wantName && ok {
+			return
+		}
+	}
+	t.Fatalf(
+		"metric name want = %v with SumData, all metrics = %v",
+		wantName, dump(t, gotNames),
+	)
+}
+
 func TestDialerWithMetrics(t *testing.T) {
 	spy := &spyMetricsExporter{}
 	view.RegisterExporter(spy)
@@ -163,6 +182,20 @@ func TestDialerWithMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected Dial to succeed, but got error: %v", err)
 	}
+	// write to conn to test bytes_sent and bytes_received
+	buf := &bytes.Buffer{}
+	err = buf.WriteByte('a')
+	if err != nil {
+		t.Fatalf("buf.WriteByte failed: %v", err)
+	}
+	_, err = conn2.Write(buf.Bytes())
+	if err != nil {
+		t.Fatalf("conn.Write failed: %v", err)
+	}
+	_, err = conn2.Read(buf.Bytes())
+	if err != nil {
+		t.Fatalf("conn.Read failed: %v", err)
+	}
 	defer conn2.Close()
 	// dial a bogus instance
 	_, err = d.Dial(ctx,
@@ -179,6 +212,8 @@ func TestDialerWithMetrics(t *testing.T) {
 	wantLastValueMetric(t, "alloydbconn/open_connections", spy.data(), 2)
 	wantDistributionMetric(t, "alloydbconn/dial_latency", spy.data())
 	wantCountMetric(t, "alloydbconn/refresh_success_count", spy.data())
+	wantSumMetric(t, "alloydbconn/bytes_sent", spy.data())
+	wantSumMetric(t, "alloydbconn/bytes_received", spy.data())
 
 	// failure metrics from dialing bogus instance
 	wantCountMetric(t, "alloydbconn/dial_failure_count", spy.data())


### PR DESCRIPTION
Port of CloudSQL's https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/856

Fixes https://github.com/GoogleCloudPlatform/alloydb-go-connector/issues/607