### PR TITLE
refactor: rename internal trace package to tel

### DIFF
--- a/internal/alloydb/refresh.go
+++ b/internal/alloydb/refresh.go
@@ -29,7 +29,7 @@ import (
 	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydb/apiv1alpha/alloydbpb"
 	"cloud.google.com/go/alloydbconn/errtype"
-	"cloud.google.com/go/alloydbconn/internal/trace"
+	"cloud.google.com/go/alloydbconn/internal/tel"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -55,8 +55,8 @@ type instanceInfo struct {
 func fetchInstanceInfo(
 	ctx context.Context, cl *alloydbadmin.AlloyDBAdminClient, inst InstanceURI,
 ) (i instanceInfo, err error) {
-	var end trace.EndSpanFunc
-	ctx, end = trace.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.FetchMetadata")
+	var end tel.EndSpanFunc
+	ctx, end = tel.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.FetchMetadata")
 	defer func() { end(err) }()
 	req := &alloydbpb.GetConnectionInfoRequest{
 		Parent: fmt.Sprintf(
@@ -123,8 +123,8 @@ func fetchClientCertificate(
 	key *rsa.PrivateKey,
 	disableMetadataExchange bool,
 ) (cc *clientCertificate, err error) {
-	var end trace.EndSpanFunc
-	ctx, end = trace.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.FetchEphemeralCert")
+	var end tel.EndSpanFunc
+	ctx, end = tel.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.FetchEphemeralCert")
 	defer func() { end(err) }()
 
 	buf := &bytes.Buffer{}
@@ -263,12 +263,12 @@ func (c adminAPIClient) connectionInfo(
 	ctx context.Context, i InstanceURI,
 ) (res ConnectionInfo, err error) {
 
-	var refreshEnd trace.EndSpanFunc
-	ctx, refreshEnd = trace.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.RefreshConnection",
-		trace.AddInstanceName(i.String()),
+	var refreshEnd tel.EndSpanFunc
+	ctx, refreshEnd = tel.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.RefreshConnection",
+		tel.AddInstanceName(i.String()),
 	)
 	defer func() {
-		go trace.RecordRefreshResult(
+		go tel.RecordRefreshResult(
 			context.Background(), i.String(), c.dialerID, err,
 		)
 		refreshEnd(err)

--- a/internal/tel/doc.go
+++ b/internal/tel/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tel provides telemetry data on the connector's internal operations.
+// The initial version is based on OpenCensus.
+package tel

--- a/internal/tel/metrics.go
+++ b/internal/tel/metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trace
+package tel
 
 import (
 	"context"

--- a/internal/tel/metrics_test.go
+++ b/internal/tel/metrics_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trace
+package tel
 
 import (
 	"errors"

--- a/internal/tel/trace.go
+++ b/internal/tel/trace.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trace
+package tel
 
 import (
 	"context"


### PR DESCRIPTION
Before introducing OpenTelemetry into this project, it's important to have a clear distinction between the existing telemetry based on OpenCensus and the new telemetry which will be based on OpenTelemetry. To do that, this commit renames the existing package containing metrics and tracing to be more generic. Later commits will introduce a "tel/v2" to make the relationship between old and new clear.