### PR TITLE
feat: match official Go version support policy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "go": "1.21",
+    "go": "1.22",
   },
   "extends": [
     "config:recommended"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,7 +115,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         goarch: ["", "386"]
-        go-version: ["1.21", "1.23"]
+        go-version: ["1.22", "1.23"]
         exclude:
           - os: macos-latest
             goarch: "386"
@@ -123,7 +123,7 @@ jobs:
             goarch: "386"
           - os: ubuntu-latest
             goarch: "386"
-            go-version: "1.21"
+            go-version: "1.22"
       fail-fast: false
     permissions:
       contents: 'read'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go/alloydbconn
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/alloydb v1.14.0


### PR DESCRIPTION
Google Cloud Go now follows the official Go support version policy. This commit updates our test infrastructure to match.