### PR TITLE
feat: add support for Go 1.24 and drop Go 1.22

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "go": "1.22",
+    "go": "1.23",
   },
   "extends": [
     "config:recommended"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: "1.23"
+        go-version: "1.24"
         cache: false
       if: ${{ matrix.language == 'go' }}
 

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false
 
       - name: Checkout base branch

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           check-latest: true
           cache: false
       - name: Checkout code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false
 
       - name: Checkout code
@@ -115,7 +115,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         goarch: ["", "386"]
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.23", "1.24"]
         exclude:
           - os: macos-latest
             goarch: "386"
@@ -123,7 +123,7 @@ jobs:
             goarch: "386"
           - os: ubuntu-latest
             goarch: "386"
-            go-version: "1.22"
+            go-version: "1.23"
       fail-fast: false
     permissions:
       contents: 'read'

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module cloud.google.com/go/alloydbconn
 
 go 1.23
 
-toolchain go1.23.6
-
 require (
 	cloud.google.com/go/alloydb v1.14.1
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module cloud.google.com/go/alloydbconn
 
-go 1.22.7
+go 1.23
 
-toolchain go1.22.12
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/alloydb v1.14.1


### PR DESCRIPTION
Go 1.22 has reach EOL, see https://endoflife.date/go. 

Go 1.24 has been released, see https://go.dev/doc/go1.24.

Fixes #655