### PR TITLE
feat: allow for disabling built-in metrics

### DIFF
--- a/database_sql_public_ip_test.go
+++ b/database_sql_public_ip_test.go
@@ -40,6 +40,7 @@ import (
 // should be called when you're done with the database connection.
 func connectDatabaseSQLWithPublicIP(
 	instURI, user, pass, dbname string,
+	opts ...alloydbconn.Option,
 ) (*sql.DB, func() error, error) {
 	// First, register the AlloyDB driver. Note, the driver's name is arbitrary
 	// and must only match what you use below in sql.Open. Also,
@@ -52,11 +53,8 @@ func connectDatabaseSQLWithPublicIP(
 	// The cleanup function will stop the dialer's background refresh
 	// goroutines. Call it when you're done with your database connection to
 	// avoid a goroutine leak.
-	cleanup, err := pgxv5.RegisterDriver(
-		"alloydb-public", alloydbconn.WithDefaultDialOptions(
-			alloydbconn.WithPublicIP(),
-		),
-	)
+	opts = append(opts, alloydbconn.WithDefaultDialOptions(alloydbconn.WithPublicIP()))
+	cleanup, err := pgxv5.RegisterDriver("alloydb-public", opts...)
 	if err != nil {
 		return nil, cleanup, err
 	}

--- a/database_sql_test.go
+++ b/database_sql_test.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"cloud.google.com/go/alloydbconn"
 	"cloud.google.com/go/alloydbconn/driver/pgxv5"
 )
 
@@ -40,6 +41,7 @@ import (
 // should be called when you're done with the database connection.
 func connectDatabaseSQL(
 	instURI, user, pass, dbname string,
+	opts ...alloydbconn.Option,
 ) (*sql.DB, func() error, error) {
 	// First, register the AlloyDB driver. Note, the driver's name is arbitrary
 	// and must only match what you use below in sql.Open. Also,
@@ -52,7 +54,7 @@ func connectDatabaseSQL(
 	// The cleanup function will stop the dialer's background refresh
 	// goroutines. Call it when you're done with your database connection to
 	// avoid a goroutine leak.
-	cleanup, err := pgxv5.RegisterDriver("alloydb")
+	cleanup, err := pgxv5.RegisterDriver("alloydb", opts...)
 	if err != nil {
 		return nil, cleanup, err
 	}

--- a/dialer.go
+++ b/dialer.go
@@ -30,7 +30,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydb/connectors/apiv1alpha/connectorspb"
 	"cloud.google.com/go/alloydbconn/debug"
 	"cloud.google.com/go/alloydbconn/errtype"
@@ -42,6 +41,9 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
+
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
+	telv2 "cloud.google.com/go/alloydbconn/internal/tel/v2"
 )
 
 const (
@@ -53,6 +55,9 @@ const (
 	// ioTimeout is the maximum amount of time to wait before aborting a
 	// metadata exhange
 	ioTimeout = 30 * time.Second
+	// metricShutdownTimeout is the maximum amount of time to wait to flush any
+	// remaining metrics when the dialer closes.
+	metricShutdownTimeout = 3 * time.Second
 )
 
 var (
@@ -142,10 +147,14 @@ type Dialer struct {
 	// should be removed.
 	disableMetadataExchange bool
 
+	// disableBuiltInMetrics turns the internal metric export into a no-op.
+	disableBuiltInMetrics bool
+
 	staticConnInfo io.Reader
 
-	client *alloydbadmin.AlloyDBAdminClient
-	logger debug.ContextLogger
+	client     *alloydbadmin.AlloyDBAdminClient
+	clientOpts []option.ClientOption
+	logger     debug.ContextLogger
 
 	// defaultDialCfg holds the constructor level DialOptions, so that it can
 	// be copied and mutated by the Dial function.
@@ -153,7 +162,9 @@ type Dialer struct {
 
 	// dialerID uniquely identifies a Dialer. Used for monitoring purposes,
 	// *only* when a client has configured OpenCensus exporters.
-	dialerID string
+	dialerID        string
+	metricsMu       sync.Mutex
+	metricRecorders map[alloydb.InstanceURI]telv2.MetricRecorder
 
 	// dialFunc is the function used to connect to the address on the named
 	// network. By default it is golang.org/x/net/proxy#Dial.
@@ -222,6 +233,7 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	if err := tel.InitMetrics(); err != nil {
 		return nil, err
 	}
+	dialerID := uuid.New().String()
 	g, err := newKeyGenerator(cfg.rsaKey, cfg.lazyRefresh,
 		func() (*rsa.PrivateKey, error) {
 			return rsa.GenerateKey(rand.Reader, 2048)
@@ -234,13 +246,16 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 		cache:                   make(map[alloydb.InstanceURI]monitoredCache),
 		lazyRefresh:             cfg.lazyRefresh,
 		disableMetadataExchange: cfg.disableMetadataExchange,
+		disableBuiltInMetrics:   cfg.disableBuiltInTelemetry,
 		staticConnInfo:          cfg.staticConnInfo,
 		keyGenerator:            g,
 		refreshTimeout:          cfg.refreshTimeout,
 		client:                  client,
+		clientOpts:              cfg.adminOpts,
 		logger:                  cfg.logger,
 		defaultDialCfg:          dialCfg,
-		dialerID:                uuid.New().String(),
+		dialerID:                dialerID,
+		metricRecorders:         map[alloydb.InstanceURI]telv2.MetricRecorder{},
 		dialFunc:                cfg.dialFunc,
 		useIAMAuthN:             cfg.useIAMAuthN,
 		iamTokenSource:          ts,
@@ -248,6 +263,27 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 		buffer:                  newBuffer(),
 	}
 	return d, nil
+}
+
+// metricRecorder does a lazy initialization of the metric exporter.
+func (d *Dialer) metricRecorder(ctx context.Context, inst alloydb.InstanceURI) telv2.MetricRecorder {
+	d.metricsMu.Lock()
+	defer d.metricsMu.Unlock()
+	if mr, ok := d.metricRecorders[inst]; ok {
+		return mr
+	}
+	cfg := telv2.Config{
+		Enabled:   !d.disableBuiltInMetrics,
+		Version:   versionString,
+		ClientID:  d.dialerID,
+		ProjectID: inst.Project(),
+		Location:  inst.Region(),
+		Cluster:   inst.Cluster(),
+		Instance:  inst.Name(),
+	}
+	mr := telv2.NewMetricRecorder(ctx, d.logger, cfg, d.clientOpts...)
+	d.metricRecorders[inst] = mr
+	return mr
 }
 
 // Dial returns a net.Conn connected to the specified AlloyDB instance. The
@@ -259,34 +295,52 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		return nil, ErrDialerClosed
 	default:
 	}
-	startTime := time.Now()
-	var endDial tel.EndSpanFunc
+
+	inst, err := alloydb.ParseInstURI(instance)
+	if err != nil {
+		return nil, err
+	}
+	mr := d.metricRecorder(ctx, inst)
+
+	var (
+		startTime = time.Now()
+		endDial   tel.EndSpanFunc
+		attrs     = telv2.Attributes{
+			IAMAuthN:    d.useIAMAuthN,
+			UserAgent:   d.userAgent,
+			RefreshType: telv2.RefreshAheadType,
+		}
+	)
+	if d.lazyRefresh {
+		attrs.RefreshType = telv2.RefreshLazyType
+	}
 	ctx, endDial = tel.StartSpan(ctx, "cloud.google.com/go/alloydbconn.Dial",
 		tel.AddInstanceName(instance),
 		tel.AddDialerID(d.dialerID),
 	)
 	defer func() {
 		go tel.RecordDialError(context.Background(), instance, d.dialerID, err)
+		go mr.RecordDialCount(ctx, attrs)
 		endDial(err)
 	}()
+
 	cfg := d.defaultDialCfg
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	inst, err := alloydb.ParseInstURI(instance)
-	if err != nil {
-		return nil, err
-	}
 
 	var endInfo tel.EndSpanFunc
 	ctx, endInfo = tel.StartSpan(ctx, "cloud.google.com/go/alloydbconn/internal.InstanceInfo")
-	cache, err := d.connectionInfoCache(ctx, inst)
+	cache, cacheHit, err := d.connectionInfoCache(ctx, inst, mr)
+	attrs.CacheHit = cacheHit
 	if err != nil {
+		attrs.DialStatus = telv2.DialCacheError
 		endInfo(err)
 		return nil, err
 	}
 	ci, err := cache.ConnectionInfo(ctx)
 	if err != nil {
+		attrs.DialStatus = telv2.DialCacheError
 		d.removeCached(ctx, inst, cache, err)
 		endInfo(err)
 		return nil, err
@@ -305,6 +359,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		ci, err = cache.ConnectionInfo(ctx)
 		if err != nil {
 			d.removeCached(ctx, inst, cache, err)
+			attrs.DialStatus = telv2.DialCacheError
 			return nil, err
 		}
 	}
@@ -315,6 +370,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 			fmt.Sprintf("instance does not have IP of type %q", cfg.ipType),
 			inst.String(),
 		)
+		attrs.DialStatus = telv2.DialUserError
 		return nil, err
 	}
 
@@ -332,13 +388,16 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		d.logger.Debugf(ctx, "[%v] Dialing %v failed: %v", inst.String(), hostPort, err)
 		// refresh the instance info in case it caused the connection failure
 		cache.ForceRefresh()
+		attrs.DialStatus = telv2.DialTCPError
 		return nil, errtype.NewDialError("failed to dial", inst.String(), err)
 	}
 	if c, ok := conn.(*net.TCPConn); ok {
 		if err := c.SetKeepAlive(true); err != nil {
+			attrs.DialStatus = telv2.DialTCPError
 			return nil, errtype.NewDialError("failed to set keep-alive", inst.String(), err)
 		}
 		if err := c.SetKeepAlivePeriod(cfg.tcpKeepAlive); err != nil {
+			attrs.DialStatus = telv2.DialTCPError
 			return nil, errtype.NewDialError("failed to set keep-alive period", inst.String(), err)
 		}
 	}
@@ -358,6 +417,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		// refresh the instance info in case it caused the handshake failure
 		cache.ForceRefresh()
 		_ = tlsConn.Close() // best effort close attempt
+		attrs.DialStatus = telv2.DialTLSError
 		return nil, errtype.NewDialError("handshake failed", inst.String(), err)
 	}
 
@@ -367,20 +427,25 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		err = d.metadataExchange(tlsConn)
 		if err != nil {
 			_ = tlsConn.Close() // best effort close attempt
+			attrs.DialStatus = telv2.DialMDXError
 			return nil, err
 		}
 	}
+	attrs.DialStatus = telv2.DialSuccess
 
 	latency := time.Since(startTime).Milliseconds()
 	go func() {
 		n := atomic.AddUint64(cache.openConns, 1)
 		tel.RecordOpenConnections(ctx, int64(n), d.dialerID, inst.String())
 		tel.RecordDialLatency(ctx, instance, d.dialerID, latency)
+		mr.RecordOpenConnection(ctx, attrs)
+		mr.RecordDialLatency(ctx, latency, attrs)
 	}()
 
-	return newInstrumentedConn(tlsConn, func() {
+	return newInstrumentedConn(tlsConn, mr, attrs, func() {
 		n := atomic.AddUint64(cache.openConns, ^uint64(0))
 		tel.RecordOpenConnections(context.Background(), int64(n), d.dialerID, inst.String())
+		mr.RecordClosedConnection(context.Background(), attrs)
 	}, d.dialerID, inst.String()), nil
 }
 
@@ -537,12 +602,14 @@ func (b *buffer) put(buf *[]byte) {
 
 // newInstrumentedConn initializes an instrumentedConn that on closing will
 // decrement the number of open connects and record the result.
-func newInstrumentedConn(conn net.Conn, closeFunc func(), dialerID, instance string) *instrumentedConn {
+func newInstrumentedConn(conn net.Conn, mr telv2.MetricRecorder, a telv2.Attributes, closeFunc func(), dialerID, instance string) *instrumentedConn {
 	return &instrumentedConn{
-		Conn:      conn,
-		closeFunc: closeFunc,
-		dialerID:  dialerID,
-		instance:  instance,
+		Conn:           conn,
+		closeFunc:      closeFunc,
+		dialerID:       dialerID,
+		instance:       instance,
+		metricRecorder: mr,
+		attrs:          a,
 	}
 }
 
@@ -550,9 +617,11 @@ func newInstrumentedConn(conn net.Conn, closeFunc func(), dialerID, instance str
 // is closed.
 type instrumentedConn struct {
 	net.Conn
-	closeFunc func()
-	dialerID  string
-	instance  string
+	closeFunc      func()
+	dialerID       string
+	instance       string
+	metricRecorder telv2.MetricRecorder
+	attrs          telv2.Attributes
 }
 
 // Read delegates to the underlying net.Conn interface and records number of
@@ -561,6 +630,7 @@ func (i *instrumentedConn) Read(b []byte) (int, error) {
 	bytesRead, err := i.Conn.Read(b)
 	if err == nil {
 		go tel.RecordBytesReceived(context.Background(), int64(bytesRead), i.instance, i.dialerID)
+		go i.metricRecorder.RecordBytesRxCount(context.Background(), int64(bytesRead), i.attrs)
 	}
 	return bytesRead, err
 }
@@ -571,6 +641,7 @@ func (i *instrumentedConn) Write(b []byte) (int, error) {
 	bytesWritten, err := i.Conn.Write(b)
 	if err == nil {
 		go tel.RecordBytesSent(context.Background(), int64(bytesWritten), i.instance, i.dialerID)
+		go i.metricRecorder.RecordBytesTxCount(context.Background(), int64(bytesWritten), i.attrs)
 	}
 	return bytesWritten, err
 }
@@ -598,16 +669,23 @@ func (d *Dialer) Close() error {
 	close(d.closed)
 
 	d.lock.Lock()
-	defer d.lock.Unlock()
 	for _, i := range d.cache {
-		i.Close()
+		_ = i.Close()
 	}
-	return nil
+	d.lock.Unlock()
+
+	d.metricsMu.Lock()
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), metricShutdownTimeout)
+	defer cancel()
+	for _, mr := range d.metricRecorders {
+		err = errors.Join(err, mr.Shutdown(ctx))
+	}
+	d.metricsMu.Unlock()
+	return err
 }
 
-func (d *Dialer) connectionInfoCache(
-	ctx context.Context, uri alloydb.InstanceURI,
-) (monitoredCache, error) {
+func (d *Dialer) connectionInfoCache(ctx context.Context, uri alloydb.InstanceURI, mr telv2.MetricRecorder) (monitoredCache, bool, error) {
 	d.lock.RLock()
 	c, ok := d.cache[uri]
 	d.lock.RUnlock()
@@ -617,14 +695,10 @@ func (d *Dialer) connectionInfoCache(
 		// Recheck to ensure instance wasn't created between locks
 		c, ok = d.cache[uri]
 		if !ok {
-			d.logger.Debugf(
-				ctx,
-				"[%v] Connection info added to cache",
-				uri.String(),
-			)
+			d.logger.Debugf(ctx, "[%v] Connection info added to cache", uri.String())
 			k, err := d.keyGenerator.rsaKey()
 			if err != nil {
-				return monitoredCache{}, err
+				return monitoredCache{}, ok, err
 			}
 			var cache connectionInfoCache
 			switch {
@@ -635,6 +709,8 @@ func (d *Dialer) connectionInfoCache(
 					d.client, k,
 					d.refreshTimeout, d.dialerID,
 					d.disableMetadataExchange,
+					d.userAgent,
+					mr,
 				)
 			case d.staticConnInfo != nil:
 				var err error
@@ -644,7 +720,7 @@ func (d *Dialer) connectionInfoCache(
 					d.staticConnInfo,
 				)
 				if err != nil {
-					return monitoredCache{}, err
+					return monitoredCache{}, ok, err
 				}
 			default:
 				cache = alloydb.NewRefreshAheadCache(
@@ -653,6 +729,8 @@ func (d *Dialer) connectionInfoCache(
 					d.client, k,
 					d.refreshTimeout, d.dialerID,
 					d.disableMetadataExchange,
+					d.userAgent,
+					mr,
 				)
 			}
 			var open uint64
@@ -660,5 +738,5 @@ func (d *Dialer) connectionInfoCache(
 			d.cache[uri] = c
 		}
 	}
-	return c, nil
+	return c, ok, nil
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -85,6 +85,7 @@ func TestPgxConnect(t *testing.T) {
 				return connectPgx(
 					ctx, alloydbInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
+					alloydbconn.WithOptOutOfBuiltInTelemetry(),
 				)
 			},
 		},
@@ -94,6 +95,7 @@ func TestPgxConnect(t *testing.T) {
 				return connectPgxWithPublicIP(
 					ctx, alloydbInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
+					alloydbconn.WithOptOutOfBuiltInTelemetry(),
 				)
 			},
 		},
@@ -103,6 +105,7 @@ func TestPgxConnect(t *testing.T) {
 				return connectPgxWithPSC(
 					ctx, alloydbPSCInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
+					alloydbconn.WithOptOutOfBuiltInTelemetry(),
 				)
 			},
 		},
@@ -113,6 +116,7 @@ func TestPgxConnect(t *testing.T) {
 					ctx, alloydbInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
 					alloydbconn.WithOptOutOfAdvancedConnectionCheck(),
+					alloydbconn.WithOptOutOfBuiltInTelemetry(),
 				)
 			},
 		},
@@ -154,7 +158,7 @@ func TestDatabaseSQLConnect(t *testing.T) {
 
 	tcs := []struct {
 		desc string
-		f    func(instURI, user, pass, dbname string) (*sql.DB, func() error, error)
+		f    func(instURI, user, pass, dbname string, opts ...alloydbconn.Option) (*sql.DB, func() error, error)
 	}{
 		{
 			desc: "private IP",
@@ -170,6 +174,7 @@ func TestDatabaseSQLConnect(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			db, cleanup, err := tc.f(
 				alloydbInstanceName, alloydbUser, alloydbPass, alloydbDB,
+				alloydbconn.WithOptOutOfBuiltInTelemetry(),
 			)
 			if err != nil {
 				_ = cleanup()
@@ -195,7 +200,7 @@ func TestDatabaseSQLConnectPGXV4(t *testing.T) {
 		t.Skip("skipping integration tests")
 	}
 
-	cleanup, err := pgxv4.RegisterDriver("alloydb-v4")
+	cleanup, err := pgxv4.RegisterDriver("alloydb-v4", alloydbconn.WithOptOutOfBuiltInTelemetry())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +236,9 @@ func TestDatabaseSQLConnectPGXV5(t *testing.T) {
 		t.Skip("skipping integration tests")
 	}
 
-	cleanup, err := pgxv5.RegisterDriver("alloydb-v5", alloydbconn.WithIAMAuthN())
+	cleanup, err := pgxv5.RegisterDriver("alloydb-v5",
+		alloydbconn.WithIAMAuthN(), alloydbconn.WithOptOutOfBuiltInTelemetry(),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +314,7 @@ func TestAutoIAMAuthN(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	d, err := alloydbconn.NewDialer(ctx, alloydbconn.WithIAMAuthN())
+	d, err := alloydbconn.NewDialer(ctx, alloydbconn.WithIAMAuthN(), alloydbconn.WithOptOutOfBuiltInTelemetry())
 	if err != nil {
 		t.Fatalf("failed to init Dialer: %v", err)
 	}

--- a/internal/alloydb/lazy.go
+++ b/internal/alloydb/lazy.go
@@ -22,17 +22,20 @@ import (
 
 	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/debug"
+	telv2 "cloud.google.com/go/alloydbconn/internal/tel/v2"
 )
 
 // LazyRefreshCache is caches connection info and refreshes the cache only when
 // a caller requests connection info and the current certificate is expired.
 type LazyRefreshCache struct {
-	uri          InstanceURI
-	logger       debug.ContextLogger
-	r            adminAPIClient
-	mu           sync.Mutex
-	needsRefresh bool
-	cached       ConnectionInfo
+	uri            InstanceURI
+	logger         debug.ContextLogger
+	r              adminAPIClient
+	mu             sync.Mutex
+	needsRefresh   bool
+	cached         ConnectionInfo
+	userAgent      string
+	metricRecorder telv2.MetricRecorder
 }
 
 // NewLazyRefreshCache initializes a new LazyRefreshCache.
@@ -44,11 +47,15 @@ func NewLazyRefreshCache(
 	_ time.Duration,
 	dialerID string,
 	disableMetadataExchange bool,
+	userAgent string,
+	mr telv2.MetricRecorder,
 ) *LazyRefreshCache {
 	return &LazyRefreshCache{
-		uri:    uri,
-		logger: l,
-		r:      newAdminAPIClient(client, key, dialerID, disableMetadataExchange),
+		uri:            uri,
+		logger:         l,
+		r:              newAdminAPIClient(client, key, dialerID, disableMetadataExchange),
+		userAgent:      userAgent,
+		metricRecorder: mr,
 	}
 }
 
@@ -88,8 +95,18 @@ func (c *LazyRefreshCache) ConnectionInfo(
 			c.uri.String(),
 			err,
 		)
+		go c.metricRecorder.RecordRefreshCount(ctx, telv2.Attributes{
+			UserAgent:     c.userAgent,
+			RefreshType:   telv2.RefreshLazyType,
+			RefreshStatus: telv2.RefreshFailure,
+		})
 		return ConnectionInfo{}, err
 	}
+	go c.metricRecorder.RecordRefreshCount(ctx, telv2.Attributes{
+		UserAgent:     c.userAgent,
+		RefreshType:   telv2.RefreshLazyType,
+		RefreshStatus: telv2.RefreshSuccess,
+	})
 	c.logger.Debugf(
 		ctx,
 		"[%v] Connection info refresh operation complete",

--- a/internal/alloydb/lazy_test.go
+++ b/internal/alloydb/lazy_test.go
@@ -16,12 +16,15 @@ package alloydb
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
-	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/internal/mock"
 	"google.golang.org/api/option"
+
+	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
+	telv2 "cloud.google.com/go/alloydbconn/internal/tel/v2"
 )
 
 func TestLazyRefreshCacheConnectionInfo(t *testing.T) {
@@ -50,6 +53,8 @@ func TestLazyRefreshCacheConnectionInfo(t *testing.T) {
 		testInstanceURI(), nullLogger{}, c,
 		rsaKey, 30*time.Second, "",
 		false,
+		"some-ua",
+		telv2.NullMetricRecorder{},
 	)
 
 	ci, err := cache.ConnectionInfo(context.Background())
@@ -93,6 +98,8 @@ func TestLazyRefreshCacheForceRefresh(t *testing.T) {
 		testInstanceURI(), nullLogger{}, c,
 		rsaKey, 30*time.Second, "",
 		false,
+		"some-ua",
+		telv2.NullMetricRecorder{},
 	)
 
 	_, err = cache.ConnectionInfo(context.Background())
@@ -105,5 +112,99 @@ func TestLazyRefreshCacheForceRefresh(t *testing.T) {
 	_, err = cache.ConnectionInfo(context.Background())
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+type mockMetricRecorder struct {
+	mu       sync.Mutex
+	gotAttrs telv2.Attributes
+
+	telv2.MetricRecorder
+}
+
+func (m *mockMetricRecorder) RecordRefreshCount(_ context.Context, a telv2.Attributes) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.gotAttrs = a
+}
+
+func (m *mockMetricRecorder) Verify(t *testing.T, wantAttrs telv2.Attributes) {
+	for range 10 {
+		m.mu.Lock()
+		gotAttrs := m.gotAttrs
+		m.mu.Unlock()
+		if gotAttrs == wantAttrs {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("got = %v, want = %v", m.gotAttrs, wantAttrs)
+}
+
+func TestLazyRefreshCacheMetrics(t *testing.T) {
+	u := testInstanceURI()
+	inst := mock.NewFakeInstance(u.project, u.region, u.cluster, u.name)
+	tcs := []struct {
+		desc      string
+		requests  []*mock.Request
+		wantAttrs telv2.Attributes
+	}{
+		{
+			desc: "refresh count success",
+			requests: []*mock.Request{
+				mock.InstanceGetSuccess(inst, 1),
+				mock.CreateEphemeralSuccess(inst, 1),
+			},
+			wantAttrs: telv2.Attributes{
+				UserAgent:     "some-ua",
+				RefreshType:   "lazy",
+				RefreshStatus: "success",
+			},
+		},
+		{
+			desc:     "refresh count success",
+			requests: []*mock.Request{}, // no requests will result in 500s
+			wantAttrs: telv2.Attributes{
+				UserAgent:     "some-ua",
+				RefreshType:   "lazy",
+				RefreshStatus: "failure",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			client, url, cleanup := mock.HTTPClient(tc.requests...)
+			defer func() {
+				if err := cleanup(); err != nil {
+					t.Fatalf("%v", err)
+				}
+			}()
+			ctx := context.Background()
+			c, err := alloydbadmin.NewAlloyDBAdminRESTClient(
+				ctx,
+				option.WithHTTPClient(client),
+				option.WithEndpoint(url),
+				option.WithTokenSource(stubTokenSource{}),
+			)
+			if err != nil {
+				t.Fatalf("expected NewClient to succeed, but got error: %v", err)
+			}
+			defer c.Close()
+
+			mockRecorder := &mockMetricRecorder{}
+			cache := NewLazyRefreshCache(
+				testInstanceURI(), nullLogger{}, c,
+				rsaKey, 30*time.Second, "",
+				false,
+				"some-ua",
+				mockRecorder,
+			)
+
+			cache.ConnectionInfo(context.Background())
+
+			mockRecorder.Verify(t, tc.wantAttrs)
+		})
 	}
 }

--- a/internal/tel/v2/tel.go
+++ b/internal/tel/v2/tel.go
@@ -114,8 +114,8 @@ type MetricRecorder interface {
 	RecordDialCount(context.Context, Attributes)
 	RecordDialLatency(context.Context, int64, Attributes)
 	RecordOpenConnection(context.Context, Attributes)
-	RecordClosedConnection(ctx context.Context, a Attributes)
-	RecordRefreshCount(ctx context.Context, a Attributes)
+	RecordClosedConnection(context.Context, Attributes)
+	RecordRefreshCount(context.Context, Attributes)
 }
 
 // DefaultExportInterval is the interval that the metric exporter runs. It
@@ -127,7 +127,7 @@ var DefaultExportInterval = 60 * time.Second
 func NewMetricRecorder(ctx context.Context, l debug.ContextLogger, cfg Config, opts ...option.ClientOption) MetricRecorder {
 	if !cfg.Enabled {
 		l.Debugf(ctx, "disabling built-in metrics")
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	eopts := []cmexporter.Option{
 		cmexporter.WithCreateServiceTimeSeries(),
@@ -143,7 +143,7 @@ func NewMetricRecorder(ctx context.Context, l debug.ContextLogger, cfg Config, o
 	exp, err := cmexporter.New(eopts...)
 	if err != nil {
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 
 	res := resource.NewWithAttributes(monitoredResource,
@@ -171,37 +171,37 @@ func NewMetricRecorder(ctx context.Context, l debug.ContextLogger, cfg Config, o
 	if err != nil {
 		_ = exp.Shutdown(ctx)
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize dial count metric: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	mDialLatency, err := m.Float64Histogram(dialLatency)
 	if err != nil {
 		_ = exp.Shutdown(ctx)
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize dial latency metric: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	mOpenConns, err := m.Int64UpDownCounter(openConnections)
 	if err != nil {
 		_ = exp.Shutdown(ctx)
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize open connections metric: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	mBytesTx, err := m.Int64Counter(bytesSent)
 	if err != nil {
 		_ = exp.Shutdown(ctx)
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize bytes sent metric: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	mBytesRx, err := m.Int64Counter(bytesReceived)
 	if err != nil {
 		_ = exp.Shutdown(ctx)
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize bytes received metric: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	mRefreshCount, err := m.Int64Counter(refreshCount)
 	if err != nil {
 		_ = exp.Shutdown(ctx)
 		l.Debugf(ctx, "built-in metrics exporter failed to initialize refresh count metric: %v", err)
-		return nullMetricRecorder{}
+		return NullMetricRecorder{}
 	}
 	return &metricRecorder{
 		exporter:      exp,
@@ -337,15 +337,30 @@ func (m *metricRecorder) RecordRefreshCount(ctx context.Context, a Attributes) {
 	)
 }
 
-// nullMetricRecorder implements the MetricRecorder interface with no-ops. It
+// NullMetricRecorder implements the MetricRecorder interface with no-ops. It
 // is useful for disabling the built-in metrics.
-type nullMetricRecorder struct{}
+type NullMetricRecorder struct{}
 
-func (nullMetricRecorder) Shutdown(context.Context) error                        { return nil }
-func (nullMetricRecorder) RecordBytesRxCount(context.Context, int64, Attributes) {}
-func (nullMetricRecorder) RecordBytesTxCount(context.Context, int64, Attributes) {}
-func (nullMetricRecorder) RecordDialCount(context.Context, Attributes)           {}
-func (nullMetricRecorder) RecordDialLatency(context.Context, int64, Attributes)  {}
-func (nullMetricRecorder) RecordOpenConnection(context.Context, Attributes)      {}
-func (nullMetricRecorder) RecordClosedConnection(context.Context, Attributes)    {}
-func (nullMetricRecorder) RecordRefreshCount(context.Context, Attributes)        {}
+// Shutdown is a no-op.
+func (NullMetricRecorder) Shutdown(context.Context) error { return nil }
+
+// RecordBytesRxCount is a no-op.
+func (NullMetricRecorder) RecordBytesRxCount(context.Context, int64, Attributes) {}
+
+// RecordBytesTxCount is a no-op.
+func (NullMetricRecorder) RecordBytesTxCount(context.Context, int64, Attributes) {}
+
+// RecordDialCount is a no-op.
+func (NullMetricRecorder) RecordDialCount(context.Context, Attributes) {}
+
+// RecordDialLatency is a no-op.
+func (NullMetricRecorder) RecordDialLatency(context.Context, int64, Attributes) {}
+
+// RecordOpenConnection is a no-op.
+func (NullMetricRecorder) RecordOpenConnection(context.Context, Attributes) {}
+
+// RecordClosedConnection is a no-op.
+func (NullMetricRecorder) RecordClosedConnection(context.Context, Attributes) {}
+
+// RecordRefreshCount is a no-op.
+func (NullMetricRecorder) RecordRefreshCount(context.Context, Attributes) {}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -165,7 +165,7 @@ func TestDialerWithMetrics(t *testing.T) {
 		t.Fatalf("expected NewClient to succeed, but got error: %v", err)
 	}
 
-	d, err := NewDialer(ctx, WithTokenSource(stubTokenSource{}))
+	d, err := NewDialer(ctx, WithTokenSource(stubTokenSource{}), WithOptOutOfBuiltInTelemetry())
 	if err != nil {
 		t.Fatalf("expected NewDialer to succeed, but got error: %v", err)
 	}

--- a/options.go
+++ b/options.go
@@ -52,6 +52,8 @@ type dialerConfig struct {
 	// disableMetadataExchange is a temporary addition and will be removed in
 	// future versions.
 	disableMetadataExchange bool
+	// disableBuiltInTelemetry disables the internal metric exporter.
+	disableBuiltInTelemetry bool
 
 	staticConnInfo io.Reader
 	// err tracks any dialer options that may have failed.
@@ -260,6 +262,18 @@ func WithStaticConnectionInfo(r io.Reader) Option {
 func WithOptOutOfAdvancedConnectionCheck() Option {
 	return func(d *dialerConfig) {
 		d.disableMetadataExchange = true
+	}
+}
+
+// WithOptOutOfBuiltInTelemetry disables the internal metric export. By
+// default, the Dialer will report on its internal operations to the
+// alloydb.googleapis.com system metric prefix. These metrics help AlloyDB
+// improve performance and identify client connectivity problems. Presently,
+// these metrics aren't public, but will be made public in the future. To
+// disable this telemetry, provide this option when initializing a Dialer.
+func WithOptOutOfBuiltInTelemetry() Option {
+	return func(d *dialerConfig) {
+		d.disableBuiltInTelemetry = true
 	}
 }
 

--- a/pgxpool_psc_test.go
+++ b/pgxpool_psc_test.go
@@ -41,13 +41,14 @@ import (
 // that should be called when you're done with the database connection.
 func connectPgxWithPSC(
 	ctx context.Context, instURI, user, pass, dbname string,
+	opts ...alloydbconn.Option,
 ) (*pgxpool.Pool, func() error, error) {
 	// First initialize the dialer. alloydbconn.NewDialer accepts additional
 	// options to configure credentials, timeouts, etc.
 	//
 	// For details, see:
 	// https://pkg.go.dev/cloud.google.com/go/alloydbconn#Option
-	d, err := alloydbconn.NewDialer(ctx)
+	d, err := alloydbconn.NewDialer(ctx, opts...)
 	if err != nil {
 		noop := func() error { return nil }
 		return nil, noop, fmt.Errorf("failed to init Dialer: %v", err)

--- a/pgxpool_public_ip_test.go
+++ b/pgxpool_public_ip_test.go
@@ -41,13 +41,14 @@ import (
 // that should be called when you're done with the database connection.
 func connectPgxWithPublicIP(
 	ctx context.Context, instURI, user, pass, dbname string,
+	opts ...alloydbconn.Option,
 ) (*pgxpool.Pool, func() error, error) {
 	// First initialize the dialer. alloydbconn.NewDialer accepts additional
 	// options to configure credentials, timeouts, etc.
 	//
 	// For details, see:
 	// https://pkg.go.dev/cloud.google.com/go/alloydbconn#Option
-	d, err := alloydbconn.NewDialer(ctx)
+	d, err := alloydbconn.NewDialer(ctx, opts...)
 	if err != nil {
 		noop := func() error { return nil }
 		return nil, noop, fmt.Errorf("failed to init Dialer: %v", err)


### PR DESCRIPTION
This commit does two things:

1. It configures the alloydbconn internals to send telemetry to AlloyDB
   reporting on the library's performance (e.g., dial count, refresh
   count, bytes tx and rx)
1. It allows callers to disable this internal telemetry.

Presently, the telemetry is not publicly readable. It is put in place in
this commit as a steel thread for improving the performance,
reliability, and diagnostics for the connector.

Future work will surface these system metrics alongside other AlloyDB
metrics for callers to use as they see fit. Unlike the existing
OpenCensus based implementation which uses custom metrics (paid for by
the caller), this implementation uses OpenTelemetry for system metrics
(paid for by AlloyDB).