### PR TITLE
fix: shut down the internal exporter only once

### DIFF
--- a/internal/tel/v2/tel.go
+++ b/internal/tel/v2/tel.go
@@ -17,7 +17,6 @@ package tel
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -231,7 +230,10 @@ type metricRecorder struct {
 
 // Shutdown should be called when the MetricRecorder is no longer needed.
 func (m *metricRecorder) Shutdown(ctx context.Context) error {
-	return errors.Join(m.exporter.Shutdown(ctx), m.provider.Shutdown(ctx))
+	// Shutdown only the provider. The provider will shutdown the exporter as
+	// part of its own shutdown, i.e., provider shuts down the reader, the
+	// reader shuts down the exporter. So one shutdown call here is enough.
+	return m.provider.Shutdown(ctx)
 }
 
 func connectorTypeValue(userAgent string) string {


### PR DESCRIPTION
The internal metrics use an exporter and a provider. Previously, when calling Close on the alloydbconn.Dialer, the code would shut down the provider and the exporter. Meanwhile, the provider also tries to shut down the exporter, leading to cases where the exporter's shutdown method was called twice.

This commit updates the Shutdown method on the internal metric reporter to shutdown only the provider (which shuts down the exporter). In addition, since internal metric shutdown errors are unactionable, this commit changes the Close method on the Dialer to log the error when debug logging is enabled and otherwise not surface it to callers.

Fixes GoogleCloudPlatform/alloydb-auth-proxy/issues/776