### PR TITLE
fix: configure Cloud Monitoring client correctly

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alloydbconn
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClientOptions(t *testing.T) {
+	tcs := []struct {
+		desc                     string
+		opt                      Option
+		wantClientOptsLen        int
+		wantAlloyDBClientOptsLen int
+	}{
+		{
+			desc:                     "WithAdminAPIEndpoint",
+			opt:                      WithAdminAPIEndpoint("some-endpoint"),
+			wantAlloyDBClientOptsLen: 1,
+			wantClientOptsLen:        0,
+		},
+		{
+			desc:                     "WithHTTPClient",
+			opt:                      WithHTTPClient(http.DefaultClient),
+			wantAlloyDBClientOptsLen: 0,
+			wantClientOptsLen:        1,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			d := &dialerConfig{}
+			tc.opt(d)
+
+			if got, want := len(d.clientOpts), tc.wantClientOptsLen; got != want {
+				t.Errorf("clientOpts: got = %v, want = %v", got, want)
+			}
+			if got, want := len(d.alloydbClientOpts), tc.wantAlloyDBClientOptsLen; got != want {
+				t.Errorf("alloydbClientOpts: got = %v, want = %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a previous commit introduced built-in metrics, it inadvertently included an API endpoint option for both the AlloyDB API client (correct) and the Cloud Monitoring client (not correct). As a result, the Cloud Monitoring client was trying to write metrics to alloydb.googleapis.com and logging the error:

transport: Error while dialing: dial tcp: lookup
tcp///alloydb.googleapis.com: unknown port

This commit add code to distinguish between AlloyDB-specific client opts (e.g., setting the Admin API endpoint) and generic client opts (e.g., setting the credentials for the client).

Fixes GoogleCloudPlatform/alloydb-auth-proxy/issues/780