### PR TITLE
deps: remove toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module cloud.google.com/go/alloydbconn
 
 go 1.23.8
 
-toolchain go1.23.10
-
 require (
 	cloud.google.com/go/alloydb v1.16.1
 	cloud.google.com/go/monitoring v1.24.2


### PR DESCRIPTION
Did not notice that https://github.com/GoogleCloudPlatform/alloydb-go-connector/pull/682 added back in the toolchain (oops!) which we don't need anymore. See https://github.com/GoogleCloudPlatform/alloydb-go-connector/pull/658#discussion_r1954947656, also re-verified it myself also using `go mod tidy`