### PR TITLE
chore: update to Go 1.25 and drop Go 1.23

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "go": "1.23",
+    "go": "1.24",
   },
   "extends": [
     "config:recommended"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,7 +115,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         goarch: ["", "386"]
-        go-version: ["1.23", "1.24"]
+        go-version: ["1.24", "1.25"]
         exclude:
           - os: macos-latest
             goarch: "386"
@@ -123,7 +123,7 @@ jobs:
             goarch: "386"
           - os: ubuntu-latest
             goarch: "386"
-            go-version: "1.23"
+            go-version: "1.24"
       fail-fast: false
     permissions:
       contents: 'read'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cloud.google.com/go/alloydbconn
 
-go 1.23.8
+go 1.24
 
 require (
 	cloud.google.com/go/alloydb v1.18.0


### PR DESCRIPTION
Go 1.23 has reached EOL: https://endoflife.date/go

Go 1.25 has released: https://go.dev/doc/go1.25

Some files have already been updated when I was merging dependency PRs for our usual monthly release. So they are not included in this PR.