### PR TITLE
fix: use correct short Instance URI form in logging

### DIFF
--- a/internal/alloydb/instance.go
+++ b/internal/alloydb/instance.go
@@ -93,7 +93,7 @@ func (i *InstanceURI) URI() string {
 
 // String returns a short-hand representation of an instance URI.
 func (i *InstanceURI) String() string {
-	return fmt.Sprintf("%s/%s/%s/%s", i.project, i.region, i.cluster, i.name)
+	return fmt.Sprintf("%s.%s.%s.%s", i.project, i.region, i.cluster, i.name)
 }
 
 // ParseInstURI initializes a new InstanceURI struct.


### PR DESCRIPTION
The Auth Proxy uses PROJECT.REGION.CLUSTER.INSTANCE. The Go Connector should use the same format. This commit corrects the mismatch, which will appear only as a logging fix.

Related to https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/126.