### PR TITLE
feat: add support for WithCredentials option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.24.0
 
 require (
 	cloud.google.com/go/alloydb v1.19.0
+	cloud.google.com/go/auth v0.17.0
+	cloud.google.com/go/auth/oauth2adapt v0.2.8
 	cloud.google.com/go/monitoring v1.24.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0
 	github.com/google/go-cmp v0.7.0
@@ -26,8 +28,6 @@ require (
 
 require (
 	cloud.google.com/go v0.120.0 // indirect
-	cloud.google.com/go/auth v0.17.0 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect

--- a/options_test.go
+++ b/options_test.go
@@ -15,9 +15,9 @@
 package alloydbconn
 
 import (
-	"context"
 	"testing"
 
+	"cloud.google.com/go/auth"
 	"golang.org/x/oauth2"
 )
 
@@ -48,11 +48,23 @@ func TestNewDialerConfig_IncompatibleOptions(t *testing.T) {
 			desc: "WithCredentialsJSON and WithTokenSource",
 			opts: []Option{WithCredentialsJSON([]byte(`sample-json`)), WithTokenSource(nullTokenSource{})},
 		},
+		{
+			desc: "WithCredentials and WihtCredentialsJSON",
+			opts: []Option{WithCredentials(&auth.Credentials{}), WithCredentialsJSON([]byte(`sample-json`))},
+		},
+		{
+			desc: "WithCredentials and WihtCredentialsFile",
+			opts: []Option{WithCredentials(&auth.Credentials{}), WithCredentialsFile("/some/file")},
+		},
+		{
+			desc: "WithCredentials and WihtTokenSource",
+			opts: []Option{WithCredentials(&auth.Credentials{}), WithTokenSource(nullTokenSource{})},
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := newDialerConfig(context.Background(), tc.opts...)
+			_, err := newDialerConfig(tc.opts...)
 			if err == nil {
 				t.Fatal("expected an error, but got nil")
 			}


### PR DESCRIPTION
This commit allows clients to configure the dialer with cloud.google.com/go/auth.Credentials.

In addition, all internal usage has been migrated to auth.Credentials. The existing credential-related options are still supported.

Fixes #646