### PR TITLE
feat: add support for short instance URIs

### DIFF
--- a/instance/uri.go
+++ b/instance/uri.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance
+
+import (
+	"fmt"
+	"regexp"
+
+	"cloud.google.com/go/alloydbconn/errtype"
+)
+
+var (
+	// Instance URI is in the format:
+	// 'projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>'
+	// Additionally, we have to support legacy "domain-scoped" projects
+	// (e.g. "google.com:PROJECT")
+	instURIRegex = regexp.MustCompile("projects/([^:]+(:[^:]+)?)/locations/([^:]+)/clusters/([^:]+)/instances/([^:]+)")
+
+	shortURI = regexp.MustCompile(`([^:]+)\.([^:]+)\.([^:]+)\.([^:]+)`)
+)
+
+// URI represents an AlloyDB instance.
+type URI struct {
+	Project string
+	Region  string
+	Cluster string
+	Name    string
+}
+
+// URI returns the full URI specifying an instance.
+func (i *URI) URI() string {
+	return fmt.Sprintf(
+		"projects/%s/locations/%s/clusters/%s/instances/%s",
+		i.Project, i.Region, i.Cluster, i.Name,
+	)
+}
+
+// Parent returns the URI specifying an instance's parent (aka cluster).
+func (i *URI) Parent() string {
+	return fmt.Sprintf(
+		"projects/%s/locations/%s/clusters/%s",
+		i.Project, i.Region, i.Cluster,
+	)
+}
+
+// String returns a short-hand representation of an instance URI.
+func (i *URI) String() string {
+	return fmt.Sprintf("%s.%s.%s.%s", i.Project, i.Region, i.Cluster, i.Name)
+}
+
+// ParseURI initializes a new InstanceURI struct.
+func ParseURI(uri string) (URI, error) {
+	b := []byte(uri)
+	m := instURIRegex.FindSubmatch(b)
+	if m == nil {
+		m2 := shortURI.FindSubmatch(b)
+		if m2 == nil {
+			err := errtype.NewConfigError(
+				"invalid instance URI, expected "+
+					"projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE> "+
+					"or <PROJECT>.<REGION>.<CLUSTER>.<INSTANCE>",
+				uri,
+			)
+			return URI{}, err
+		}
+		return URI{
+			Project: string(m2[1]),
+			Region:  string(m2[2]),
+			Cluster: string(m2[3]),
+			Name:    string(m2[4]),
+		}, nil
+	}
+
+	c := URI{
+		Project: string(m[1]),
+		Region:  string(m[3]),
+		Cluster: string(m[4]),
+		Name:    string(m[5]),
+	}
+	return c, nil
+}

--- a/instance/uri_test.go
+++ b/instance/uri_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance_test
+
+import (
+	"testing"
+
+	"cloud.google.com/go/alloydbconn/instance"
+)
+
+
+func TestParseInstURI(t *testing.T) {
+	tcs := []struct {
+		desc string
+		in   string
+		want instance.URI
+	}{
+		{
+			desc: "vanilla instance URI",
+			in:   "projects/proj/locations/reg/clusters/clust/instances/name",
+			want: instance.URI{
+				Project: "proj",
+				Region:  "reg",
+				Cluster: "clust",
+				Name:    "name",
+			},
+		},
+		{
+			desc: "with legacy domain-scoped project",
+			in:   "projects/google.com:proj/locations/reg/clusters/clust/instances/name",
+			want: instance.URI{
+				Project: "google.com:proj",
+				Region:  "reg",
+				Cluster: "clust",
+				Name:    "name",
+			},
+		},
+		{
+			desc: "with psuedo-DNS style",
+			in:   "proj.reg.clust.name",
+			want: instance.URI{
+				Project: "proj",
+				Region:  "reg",
+				Cluster: "clust",
+				Name:    "name",
+			},
+		},
+		{
+			desc: "with psuedo-DNS style and legacy domain-scoped project",
+			in:   "google.com:proj.reg.clust.name",
+			want: instance.URI{
+				Project: "proj",
+				Region:  "reg",
+				Cluster: "clust",
+				Name:    "name",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := instance.ParseURI(tc.in)
+			if err != nil {
+				t.Fatalf("got = %v, want no error", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got = %v, want = %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseConnNameErrors(t *testing.T) {
+	tcs := []struct {
+		desc string
+		in   string
+	}{
+		{
+			desc: "malformatted",
+			in:   "not-correct",
+		},
+		{
+			desc: "missing project",
+			in:   "reg:clust:name",
+		},
+		{
+			desc: "missing cluster",
+			in:   "proj:reg:name",
+		},
+		{
+			desc: "empty",
+			in:   "::::",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := instance.ParseURI(tc.in)
+			if err == nil {
+				t.Fatal("want error, got nil")
+			}
+		})
+	}
+}
+

--- a/internal/alloydb/lazy.go
+++ b/internal/alloydb/lazy.go
@@ -22,13 +22,14 @@ import (
 
 	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
 	"cloud.google.com/go/alloydbconn/debug"
+	"cloud.google.com/go/alloydbconn/instance"
 	telv2 "cloud.google.com/go/alloydbconn/internal/tel/v2"
 )
 
 // LazyRefreshCache is caches connection info and refreshes the cache only when
 // a caller requests connection info and the current certificate is expired.
 type LazyRefreshCache struct {
-	uri            InstanceURI
+	uri            instance.URI
 	logger         debug.ContextLogger
 	r              adminAPIClient
 	mu             sync.Mutex
@@ -40,7 +41,7 @@ type LazyRefreshCache struct {
 
 // NewLazyRefreshCache initializes a new LazyRefreshCache.
 func NewLazyRefreshCache(
-	uri InstanceURI,
+	uri instance.URI,
 	l debug.ContextLogger,
 	client *alloydbadmin.AlloyDBAdminClient,
 	key *rsa.PrivateKey,

--- a/internal/alloydb/lazy_test.go
+++ b/internal/alloydb/lazy_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestLazyRefreshCacheConnectionInfo(t *testing.T) {
 	u := testInstanceURI()
-	inst := mock.NewFakeInstance(u.project, u.region, u.cluster, u.name)
+	inst := mock.NewFakeInstance(u.Project, u.Region, u.Cluster, u.Name)
 	client, url, cleanup := mock.HTTPClient(
 		mock.InstanceGetSuccess(inst, 1),
 		mock.CreateEphemeralSuccess(inst, 1),
@@ -74,7 +74,7 @@ func TestLazyRefreshCacheConnectionInfo(t *testing.T) {
 
 func TestLazyRefreshCacheForceRefresh(t *testing.T) {
 	u := testInstanceURI()
-	inst := mock.NewFakeInstance(u.project, u.region, u.cluster, u.name)
+	inst := mock.NewFakeInstance(u.Project, u.Region, u.Cluster, u.Name)
 	client, url, cleanup := mock.HTTPClient(
 		mock.InstanceGetSuccess(inst, 2),
 		mock.CreateEphemeralSuccess(inst, 2),
@@ -144,7 +144,7 @@ func (m *mockMetricRecorder) Verify(t *testing.T, wantAttrs telv2.Attributes) {
 
 func TestLazyRefreshCacheMetrics(t *testing.T) {
 	u := testInstanceURI()
-	inst := mock.NewFakeInstance(u.project, u.region, u.cluster, u.name)
+	inst := mock.NewFakeInstance(u.Project, u.Region, u.Cluster, u.Name)
 	tcs := []struct {
 		desc      string
 		requests  []*mock.Request

--- a/internal/alloydb/refresh_test.go
+++ b/internal/alloydb/refresh_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
+	"cloud.google.com/go/alloydbconn/instance"
 	"cloud.google.com/go/alloydbconn/internal/mock"
 	"google.golang.org/api/option"
 )
@@ -33,7 +34,7 @@ func TestRefresh(t *testing.T) {
 	wantPSC := "x.y.alloydb.goog"
 	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
 	wantInstURI := "projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"
-	cn, err := ParseInstURI(wantInstURI)
+	cn, err := instance.ParseURI(wantInstURI)
 	if err != nil {
 		t.Fatalf("parseConnName(%s)failed : %v", cn, err)
 	}
@@ -99,7 +100,7 @@ func TestRefresh(t *testing.T) {
 
 func TestRefreshFailsFast(t *testing.T) {
 	wantInstURI := "projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"
-	cn, err := ParseInstURI(wantInstURI)
+	cn, err := instance.ParseURI(wantInstURI)
 	if err != nil {
 		t.Fatalf("parseConnName(%s)failed : %v", cn, err)
 	}


### PR DESCRIPTION
Prior to this commit, callers had to specify a full instance URI like this:

``` go
d, _ := alloydbconn.NewDialer(ctx)

d.Dial(ctx,
    "projects/<PROJECT>/locations/<LOCATION>/clusters/<CLUSTER>/instances/<INSTANCE>")
```

This is overly cumbersome. Instead, this commit adds support for a "short URI" like this:

``` go
d, _ := alloydbconn.NewDialer(ctx)

d.Dial(ctx, "myproject.us-central1.mycluster.myinstance")
```

In order to make this change usable in the Auth Proxy, this commit moves the parsing code into a new "instance" package and renames InstanceURI to just URI to avoid package name stuttering. Its use now looks like this:

``` go
u, err := instance.ParseURI("<SHORT OR LONG URI>")
```