### PR TITLE
docs: correct `database/sql` snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ import (
 )
 
 func Connect() {
-    cleanup, err := pgxv5.RegisterDriver("alloydb", alloydbconn.WithPublicIP())
+    cleanup, err := pgxv5.RegisterDriver("alloydb", alloydbconn.WithDefaultDialOptions(alloydbconn.WithPublicIP()))
     if err != nil {
         // ... handle error
     }


### PR DESCRIPTION
`RegisterDriver` accepts `alloydbconn.Option` not `alloydbconn.DialOption`.