### PR TITLE
feat: add support for login scope

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -170,8 +170,8 @@ type Dialer struct {
 	// network. By default it is golang.org/x/net/proxy#Dial.
 	dialFunc func(cxt context.Context, network, addr string) (net.Conn, error)
 
-	iamTokenSource auth.TokenProvider
-	userAgent      string
+	iamAuthNTokenProvider auth.TokenProvider
+	userAgent             string
 
 	buffer *buffer
 }
@@ -233,7 +233,7 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 		dialerID:                dialerID,
 		metricRecorders:         map[alloydb.InstanceURI]telv2.MetricRecorder{},
 		dialFunc:                cfg.dialFunc,
-		iamTokenSource:          cfg.tokenProvider,
+		iamAuthNTokenProvider:   cfg.iamAuthNTokenProvider,
 		userAgent:               userAgent,
 		buffer:                  newBuffer(),
 	}
@@ -479,7 +479,7 @@ func invalidClientCert(
 //
 // Subsequent interactions with the server use the database protocol.
 func (d *Dialer) metadataExchange(ctx context.Context, conn net.Conn, useIAMAuthN bool) error {
-	tok, err := d.iamTokenSource.Token(ctx)
+	tok, err := d.iamAuthNTokenProvider.Token(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit ensures the OAuth2 token used for IAM authentication is
scoped to https://www.googleapis.com/auth/alloydb.login.

When callers provide their own oauth2.TokenSource or auth.Credentials,
they may also now provide an oauth2.TokenSource or auth.Credentials for
IAM authentication by using one of the new options
WithIAMAuthTokenSource or WithIAMAuthNCredentials.

Fixes https://github.com/GoogleCloudPlatform/alloydb-go-connector/issues/432