### PR TITLE
chore: remove noisy metric exporter logs

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -691,12 +691,9 @@ func (d *Dialer) Close() error {
 	ctx, cancel := context.WithTimeout(context.Background(), metricShutdownTimeout)
 	defer cancel()
 	for _, mr := range d.metricRecorders {
-		// If a metric recorder doesn't shutdown cleanly, log the error and
-		// keep going. An error here isn't actionable and should not be
-		// returned to the caller.
-		if err := mr.Shutdown(ctx); err != nil {
-			d.logger.Debugf(context.Background(), "internal metric exporter failed to shutdown: %v", err)
-		}
+		// Best effort shutdown for internal metric exporter. An error here
+		// isn't actionable and is just noise.
+		_ = mr.Shutdown(ctx)
 	}
 	d.metricsMu.Unlock()
 	return nil


### PR DESCRIPTION
When the Go Connector is closed before an exporter can run, it will complain about having to drop some time series data in the debug logs. These logs aren't actionable, are for internal-only concerns, and will always occur as the Go Connector will never wait for the metrics to flush.

So this commit removes this noisy log.

Related to
https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/787.