### PR TITLE
feat: Add UniverseDomain option for TPC support

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -188,8 +188,8 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 
 	cOpts := append(cfg.alloydbClientOpts, cfg.clientOpts...)
 	// If universe domain was resolved via env var rather than explicit WithUniverseDomain option:
-	if cfg.universeDomain == "" && cfg.getClientUniverseDomain() != defaultUniverseDomain {
-		cOpts = append(cOpts, option.WithUniverseDomain(cfg.getClientUniverseDomain()))
+	if cfg.universeDomain == "" && cfg.clientUniverseDomain() != defaultUniverseDomain {
+		cOpts = append(cOpts, option.WithUniverseDomain(cfg.clientUniverseDomain()))
 	}
 
 	client, err := alloydbadmin.NewAlloyDBAdminRESTClient(ctx, cOpts...)

--- a/dialer.go
+++ b/dialer.go
@@ -37,6 +37,7 @@ import (
 	"cloud.google.com/go/alloydbconn/internal/tel"
 	"cloud.google.com/go/auth"
 	"github.com/google/uuid"
+	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
 
 	alloydbadmin "cloud.google.com/go/alloydb/apiv1alpha"
@@ -186,6 +187,11 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	}
 
 	cOpts := append(cfg.alloydbClientOpts, cfg.clientOpts...)
+	// If universe domain was resolved via env var rather than explicit WithUniverseDomain option:
+	if cfg.universeDomain == "" && cfg.getClientUniverseDomain() != defaultUniverseDomain {
+		cOpts = append(cOpts, option.WithUniverseDomain(cfg.getClientUniverseDomain()))
+	}
+
 	client, err := alloydbadmin.NewAlloyDBAdminRESTClient(ctx, cOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AlloyDB Admin API client: %v", err)

--- a/dialer.go
+++ b/dialer.go
@@ -187,7 +187,7 @@ func NewDialer(ctx context.Context, opts ...Option) (*Dialer, error) {
 	}
 
 	cOpts := append(cfg.alloydbClientOpts, cfg.clientOpts...)
-	// If universe domain was resolved via env var rather than explicit WithUniverseDomain option:
+	// If set, add WithUniverseDomain option.
 	if cfg.universeDomain == "" && cfg.clientUniverseDomain() != defaultUniverseDomain {
 		cOpts = append(cOpts, option.WithUniverseDomain(cfg.clientUniverseDomain()))
 	}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -572,6 +572,102 @@ func TestDialerClose(t *testing.T) {
 	}
 }
 
+// TestDialerWithUniverseDomainOption verifies NewDialer succeeds when WithUniverseDomain is used.
+func TestDialerWithUniverseDomainOption(t *testing.T) {
+	ctx := context.Background()
+	inst := mock.NewFakeInstance("my-project", "my-region", "my-cluster", "my-instance")
+	mc, url, cleanup := mock.HTTPClient(
+		mock.InstanceGetSuccess(inst, 1),
+		mock.CreateEphemeralSuccess(inst, 1),
+	)
+	stop := mock.StartServerProxy(t, inst)
+	defer func() {
+		stop()
+		if err := cleanup(); err != nil {
+			t.Fatalf("%v", err)
+		}
+	}()
+	c, err := alloydbadmin.NewAlloyDBAdminRESTClient(
+		ctx,
+		option.WithHTTPClient(mc),
+		option.WithEndpoint(url),
+		option.WithUniverseDomain("my-universe.cloud"),
+	)
+	if err != nil {
+		t.Fatalf("expected NewClient to succeed, got: %v", err)
+	}
+	d, err := NewDialer(
+		ctx,
+		WithTokenSource(stubTokenSource{}),
+		WithUniverseDomain("my-universe.cloud"),
+		WithOptOutOfBuiltInTelemetry(),
+	)
+	if err != nil {
+		t.Fatalf("expected NewDialer to succeed, got: %v", err)
+	}
+	d.client = c
+	conn, err := d.Dial(ctx, testInstanceURI)
+	if err != nil {
+		t.Fatalf("expected Dial to succeed, got: %v", err)
+	}
+	defer conn.Close()
+	data, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("expected ReadAll to succeed, got: %v", err)
+	}
+	if string(data) != "my-instance" {
+		t.Fatalf("expected known response 'my-instance', got %v", string(data))
+	}
+}
+
+// TestDialerWithUniverseDomainEnvVar verifies NewDialer resolves the domain via GOOGLE_CLOUD_UNIVERSE_DOMAIN.
+func TestDialerWithUniverseDomainEnvVar(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "sovereign-cloud.de")
+	inst := mock.NewFakeInstance("my-project", "my-region", "my-cluster", "my-instance")
+	mc, url, cleanup := mock.HTTPClient(
+		mock.InstanceGetSuccess(inst, 1),
+		mock.CreateEphemeralSuccess(inst, 1),
+	)
+	stop := mock.StartServerProxy(t, inst)
+	defer func() {
+		stop()
+		if err := cleanup(); err != nil {
+			t.Fatalf("%v", err)
+		}
+	}()
+	c, err := alloydbadmin.NewAlloyDBAdminRESTClient(
+		ctx,
+		option.WithHTTPClient(mc),
+		option.WithEndpoint(url),
+		option.WithUniverseDomain("sovereign-cloud.de"),
+	)
+	if err != nil {
+		t.Fatalf("expected NewClient to succeed, got: %v", err)
+	}
+	d, err := NewDialer(
+		ctx,
+		WithTokenSource(stubTokenSource{}),
+		WithOptOutOfBuiltInTelemetry(),
+	)
+	if err != nil {
+		t.Fatalf("expected NewDialer to succeed, got: %v", err)
+	}
+	d.client = c
+	conn, err := d.Dial(ctx, testInstanceURI)
+	if err != nil {
+		t.Fatalf("expected Dial to succeed, got: %v", err)
+	}
+	defer conn.Close()
+	data, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("expected ReadAll to succeed, got: %v", err)
+	}
+	if string(data) != "my-instance" {
+		t.Fatalf("expected known response 'my-instance', got %v", string(data))
+	}
+}
+
 type mockMetricRecorder struct {
 	mu          sync.Mutex
 	gotAttrs    telv2.Attributes

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -50,7 +50,7 @@ var (
 	alloydbPass = os.Getenv("ALLOYDB_PASS")
 	// Name of the database to connect to.
 	alloydbDB = os.Getenv("ALLOYDB_DB")
-	// Name of universe domain
+	// Name of universe domain.
 	alloydbUniverseDomain = os.Getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
 )
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -50,6 +50,8 @@ var (
 	alloydbPass = os.Getenv("ALLOYDB_PASS")
 	// Name of the database to connect to.
 	alloydbDB = os.Getenv("ALLOYDB_DB")
+	// Name of universe domain
+	alloydbUniverseDomain = os.Getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
 )
 
 func requireAlloyDBVars(t *testing.T) {
@@ -86,7 +88,7 @@ func TestPgxConnect(t *testing.T) {
 				return connectPgx(
 					ctx, alloydbInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
-					alloydbconn.WithOptOutOfBuiltInTelemetry(),
+					alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 				)
 			},
 		},
@@ -96,7 +98,7 @@ func TestPgxConnect(t *testing.T) {
 				return connectPgxWithPublicIP(
 					ctx, alloydbInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
-					alloydbconn.WithOptOutOfBuiltInTelemetry(),
+					alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 				)
 			},
 		},
@@ -106,7 +108,7 @@ func TestPgxConnect(t *testing.T) {
 				return connectPgxWithPSC(
 					ctx, alloydbPSCInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
-					alloydbconn.WithOptOutOfBuiltInTelemetry(),
+					alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 				)
 			},
 		},
@@ -117,7 +119,7 @@ func TestPgxConnect(t *testing.T) {
 					ctx, alloydbInstanceName,
 					alloydbUser, alloydbPass, alloydbDB,
 					alloydbconn.WithOptOutOfAdvancedConnectionCheck(),
-					alloydbconn.WithOptOutOfBuiltInTelemetry(),
+					alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 				)
 			},
 		},
@@ -174,7 +176,7 @@ func TestDatabaseSQLConnect(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			db, cleanup, err := tc.f(
 				alloydbInstanceName, alloydbUser, alloydbPass, alloydbDB,
-				alloydbconn.WithOptOutOfBuiltInTelemetry(),
+				alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 			)
 			if err != nil {
 				_ = cleanup()
@@ -200,7 +202,7 @@ func TestDatabaseSQLConnectPGXV4(t *testing.T) {
 		t.Skip("skipping integration tests")
 	}
 
-	cleanup, err := pgxv4.RegisterDriver("alloydb-v4", alloydbconn.WithOptOutOfBuiltInTelemetry())
+	cleanup, err := pgxv4.RegisterDriver("alloydb-v4", alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +239,7 @@ func TestDatabaseSQLConnectPostgres(t *testing.T) {
 	}
 
 	cleanup, err := postgres.RegisterDriver("alloydb-postgres",
-		alloydbconn.WithIAMAuthN(), alloydbconn.WithOptOutOfBuiltInTelemetry(),
+		alloydbconn.WithIAMAuthN(), alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -275,7 +277,7 @@ func TestDatabaseSQLConnectPGXV5(t *testing.T) {
 	}
 
 	cleanup, err := pgxv5.RegisterDriver("alloydb-v5",
-		alloydbconn.WithIAMAuthN(), alloydbconn.WithOptOutOfBuiltInTelemetry(),
+		alloydbconn.WithIAMAuthN(), alloydbconn.WithOptOutOfBuiltInTelemetry(), alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -361,6 +363,7 @@ func TestAutoIAMAuthN(t *testing.T) {
 			opts: []alloydbconn.Option{
 				alloydbconn.WithIAMAuthN(),
 				alloydbconn.WithOptOutOfBuiltInTelemetry(),
+				alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 			},
 			wantIAMAuthN: true,
 		},
@@ -368,6 +371,7 @@ func TestAutoIAMAuthN(t *testing.T) {
 			desc: "dialer with IAM authn off, dial on",
 			opts: []alloydbconn.Option{
 				alloydbconn.WithOptOutOfBuiltInTelemetry(),
+				alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 			},
 			dialOpts: []alloydbconn.DialOption{
 				alloydbconn.WithDialIAMAuthN(true),
@@ -379,6 +383,7 @@ func TestAutoIAMAuthN(t *testing.T) {
 			opts: []alloydbconn.Option{
 				alloydbconn.WithIAMAuthN(),
 				alloydbconn.WithOptOutOfBuiltInTelemetry(),
+				alloydbconn.WithUniverseDomain(alloydbUniverseDomain),
 			},
 			dialOpts: []alloydbconn.DialOption{
 				alloydbconn.WithDialIAMAuthN(false),

--- a/options.go
+++ b/options.go
@@ -39,8 +39,13 @@ import (
 const (
 	// CloudPlatformScope is the default OAuth2 scope set on the API client.
 	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
-	// AlloyDBLoginScope is the OAuth2 scope used for IAM Authentication
+	// AlloyDBLoginScope is the OAuth2 scope used for IAM Authentication.
 	AlloyDBLoginScope = "https://www.googleapis.com/auth/alloydb.login"
+
+	// Default GDU API Domain.
+	defaultUniverseDomain = "googleapis.com"
+	// Universe Domain, either GDU or TPC.
+	universeDomainEnvVar = "GOOGLE_CLOUD_UNIVERSE_DOMAIN"
 )
 
 // An Option is an option for configuring a Dialer.
@@ -78,42 +83,45 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{CloudPlatformScope},
+			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
 			CredentialsJSON: b,
+			UniverseDomain:  d.getClientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
-
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
 		// Now rebuild credentials with the Login Scope
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{AlloyDBLoginScope},
+			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
 			CredentialsJSON: b,
+			UniverseDomain:  d.getClientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.iamAuthNTokenProvider = c.TokenProvider
+		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
 	case d.credentialsJSON != nil:
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{CloudPlatformScope},
+			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
 			CredentialsJSON: d.credentialsJSON,
+			UniverseDomain:  d.getClientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
 
 		// Now rebuild credentials with the Login Scope
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{AlloyDBLoginScope},
+			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
 			CredentialsJSON: d.credentialsJSON,
+			UniverseDomain:  d.getClientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.iamAuthNTokenProvider = c.TokenProvider
+		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
 	case d.tokenProvider != nil:
 		c := auth.NewCredentials(&auth.CredentialsOptions{
 			TokenProvider: d.tokenProvider,
@@ -121,26 +129,28 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
 		d.iamAuthNTokenProvider = d.tokenProvider
 	case d.credentials != nil:
-		d.iamAuthNTokenProvider = d.credentials.TokenProvider
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(d.credentials))
+		c := WithUniverseDomainCredentials(d.credentials, d.getClientUniverseDomain())
+		d.iamAuthNTokenProvider = c.TokenProvider
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
 	default:
 		// If a credentials file, credentials JSON, or a token source was not provided,
 		// default to Application Default Credentials.
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes: []string{CloudPlatformScope},
+			Scopes:         []string{AlloyDBLoginScope},
+			UniverseDomain: d.getClientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, err
 		}
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
-
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes: []string{AlloyDBLoginScope},
+			Scopes:         []string{AlloyDBLoginScope},
+			UniverseDomain: d.getClientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, err
 		}
-		d.iamAuthNTokenProvider = c.TokenProvider
+		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
 	}
 
 	if d.iamAuthNTokenProviderOverride != nil {
@@ -162,6 +172,22 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 	return d, nil
 }
 
+// getClientUniverseDomain returns the default service domain for a given Cloud
+// universe, with the following precedence:
+//
+// 1. A non-empty option.WithUniverseDomain or similar client option.
+// 2. A non-empty environment variable GOOGLE_CLOUD_UNIVERSE_DOMAIN.
+// 3. The default value "googleapis.com".
+func (d *dialerConfig) getClientUniverseDomain() string {
+	if d.universeDomain != "" {
+		return d.universeDomain
+	}
+	if envUD := os.Getenv(universeDomainEnvVar); envUD != "" {
+		return envUD
+	}
+	return defaultUniverseDomain
+}
+
 type dialerConfig struct {
 	rsaKey *rsa.PrivateKey
 	// alloydbClientOpts are options to configure only the AlloyDB Rest API
@@ -179,6 +205,7 @@ type dialerConfig struct {
 	logger           debug.ContextLogger
 	lazyRefresh      bool
 	adminAPIEndpoint string
+	universeDomain   string
 
 	credentials           *auth.Credentials
 	tokenProvider         auth.TokenProvider
@@ -195,6 +222,38 @@ type dialerConfig struct {
 	disableBuiltInTelemetry bool
 
 	staticConnInfo io.Reader
+}
+
+// WithUniverseDomain configures the underlying AlloyDB Admin API client and
+// credentials to use the provided universe domain. Enables Trusted Partner Cloud (TPC).
+func WithUniverseDomain(ud string) Option {
+	return func(d *dialerConfig) {
+		if ud == "" {
+			return
+		}
+		d.universeDomain = ud
+		d.alloydbClientOpts = append(d.alloydbClientOpts, option.WithUniverseDomain(ud))
+	}
+}
+
+// WithUniverseDomainCredentials configures custom credential to be TPC aware.
+func WithUniverseDomainCredentials(c *auth.Credentials, ud string) *auth.Credentials {
+	if c == nil || ud == "" || ud == defaultUniverseDomain {
+		return c
+	}
+	return auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: c.TokenProvider,
+		JSON:          c.JSON(),
+		ProjectIDProvider: auth.CredentialsPropertyFunc(func(ctx context.Context) (string, error) {
+			return c.ProjectID(ctx)
+		}),
+		QuotaProjectIDProvider: auth.CredentialsPropertyFunc(func(ctx context.Context) (string, error) {
+			return c.QuotaProjectID(ctx)
+		}),
+		UniverseDomainProvider: auth.CredentialsPropertyFunc(func(_ context.Context) (string, error) {
+			return ud, nil
+		}),
+	})
 }
 
 // WithOptions turns a list of Option's into a single Option.

--- a/options.go
+++ b/options.go
@@ -44,8 +44,6 @@ const (
 
 	// Default GDU API Domain.
 	defaultUniverseDomain = "googleapis.com"
-	// Universe Domain, either GDU or TPC.
-	universeDomainEnvVar = "GOOGLE_CLOUD_UNIVERSE_DOMAIN"
 )
 
 // An Option is an option for configuring a Dialer.
@@ -86,43 +84,43 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes:          []string{CloudPlatformScope},
 			CredentialsJSON: b,
-			UniverseDomain:  d.getClientUniverseDomain(),
+			UniverseDomain:  d.clientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.clientUniverseDomain())))
 		// Now rebuild credentials with the Login Scope
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes:          []string{AlloyDBLoginScope},
 			CredentialsJSON: b,
-			UniverseDomain:  d.getClientUniverseDomain(),
+			UniverseDomain:  d.clientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
+		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.clientUniverseDomain()).TokenProvider
 	case d.credentialsJSON != nil:
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes:          []string{CloudPlatformScope},
 			CredentialsJSON: d.credentialsJSON,
-			UniverseDomain:  d.getClientUniverseDomain(),
+			UniverseDomain:  d.clientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.clientUniverseDomain())))
 
 		// Now rebuild credentials with the Login Scope
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes:          []string{AlloyDBLoginScope},
 			CredentialsJSON: d.credentialsJSON,
-			UniverseDomain:  d.getClientUniverseDomain(),
+			UniverseDomain:  d.clientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
-		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
+		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.clientUniverseDomain()).TokenProvider
 	case d.tokenProvider != nil:
 		c := auth.NewCredentials(&auth.CredentialsOptions{
 			TokenProvider: d.tokenProvider,
@@ -130,7 +128,7 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
 		d.iamAuthNTokenProvider = d.tokenProvider
 	case d.credentials != nil:
-		c := WithUniverseDomainCredentials(d.credentials, d.getClientUniverseDomain())
+		c := WithUniverseDomainCredentials(d.credentials, d.clientUniverseDomain())
 		d.iamAuthNTokenProvider = c.TokenProvider
 		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(c))
 	default:
@@ -138,20 +136,20 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		// default to Application Default Credentials.
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes:         []string{CloudPlatformScope},
-			UniverseDomain: d.getClientUniverseDomain(),
+			UniverseDomain: d.clientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, err
 		}
-		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
+		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.clientUniverseDomain())))
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes:         []string{AlloyDBLoginScope},
-			UniverseDomain: d.getClientUniverseDomain(),
+			UniverseDomain: d.clientUniverseDomain(),
 		})
 		if err != nil {
 			return nil, err
 		}
-		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
+		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.clientUniverseDomain()).TokenProvider
 	}
 
 	if d.iamAuthNTokenProviderOverride != nil {
@@ -173,18 +171,14 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 	return d, nil
 }
 
-// getClientUniverseDomain returns the default service domain for a given Cloud
+// clientUniverseDomain returns the default service domain for a given Cloud
 // universe, with the following precedence:
 //
 // 1. A non-empty option.WithUniverseDomain or similar client option.
-// 2. A non-empty environment variable GOOGLE_CLOUD_UNIVERSE_DOMAIN.
-// 3. The default value "googleapis.com".
-func (d *dialerConfig) getClientUniverseDomain() string {
+// 2. The default value "googleapis.com".
+func (d *dialerConfig) clientUniverseDomain() string {
 	if d.universeDomain != "" {
 		return d.universeDomain
-	}
-	if envUD := os.Getenv(universeDomainEnvVar); envUD != "" {
-		return envUD
 	}
 	return defaultUniverseDomain
 }

--- a/options.go
+++ b/options.go
@@ -63,12 +63,13 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 	}
 
 	badPairs := map[bool]string{
-		d.credentialsFile != "" && d.credentialsJSON != nil: "incompatible options: WithCredentialsFile cannot be used with WithCredentialsJSON",
-		d.credentialsFile != "" && d.tokenProvider != nil:   "incompatible options: WithCredentialsFile cannot be used with WithTokenSource",
-		d.credentialsJSON != nil && d.tokenProvider != nil:  "incompatible options: WithCredentialsJSON cannot be used with WithTokenSource",
-		d.credentials != nil && d.credentialsFile != "":     "incompatible options: WithCredentials cannot be used with WithCredentialsFile",
-		d.credentials != nil && d.credentialsJSON != nil:    "incompatible options: WithCredentials cannot be used with WithCredentialsJSON",
-		d.credentials != nil && d.tokenProvider != nil:      "incompatible options: WithCredentials cannot be used with WithTokenSource",
+		d.credentialsFile != "" && d.credentialsJSON != nil:              "incompatible options: WithCredentialsFile cannot be used with WithCredentialsJSON",
+		d.credentialsFile != "" && d.tokenProvider != nil:                "incompatible options: WithCredentialsFile cannot be used with WithTokenSource",
+		d.credentialsJSON != nil && d.tokenProvider != nil:               "incompatible options: WithCredentialsJSON cannot be used with WithTokenSource",
+		d.credentials != nil && d.credentialsFile != "":                  "incompatible options: WithCredentials cannot be used with WithCredentialsFile",
+		d.credentials != nil && d.credentialsJSON != nil:                 "incompatible options: WithCredentials cannot be used with WithCredentialsJSON",
+		d.credentials != nil && d.tokenProvider != nil:                   "incompatible options: WithCredentials cannot be used with WithTokenSource",
+		d.adminAPIEndpoint != "" && d.universeDomain != "googleapis.com": "incompatible options: WithAdminAPIEndpoint cannot be used with TPC UniverseDomain",
 	}
 	for bad, msg := range badPairs {
 		if bad {
@@ -83,7 +84,7 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 			return nil, errtype.NewConfigError(err.Error(), "n/a")
 		}
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
+			Scopes:          []string{CloudPlatformScope},
 			CredentialsJSON: b,
 			UniverseDomain:  d.getClientUniverseDomain(),
 		})
@@ -93,7 +94,7 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		d.clientOpts = append(d.clientOpts, option.WithAuthCredentials(WithUniverseDomainCredentials(c, d.getClientUniverseDomain())))
 		// Now rebuild credentials with the Login Scope
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
+			Scopes:          []string{AlloyDBLoginScope},
 			CredentialsJSON: b,
 			UniverseDomain:  d.getClientUniverseDomain(),
 		})
@@ -103,7 +104,7 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		d.iamAuthNTokenProvider = WithUniverseDomainCredentials(c, d.getClientUniverseDomain()).TokenProvider
 	case d.credentialsJSON != nil:
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
+			Scopes:          []string{CloudPlatformScope},
 			CredentialsJSON: d.credentialsJSON,
 			UniverseDomain:  d.getClientUniverseDomain(),
 		})
@@ -114,7 +115,7 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 
 		// Now rebuild credentials with the Login Scope
 		c, err = credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:          []string{CloudPlatformScope, AlloyDBLoginScope},
+			Scopes:          []string{AlloyDBLoginScope},
 			CredentialsJSON: d.credentialsJSON,
 			UniverseDomain:  d.getClientUniverseDomain(),
 		})
@@ -136,7 +137,7 @@ func newDialerConfig(opts ...Option) (*dialerConfig, error) {
 		// If a credentials file, credentials JSON, or a token source was not provided,
 		// default to Application Default Credentials.
 		c, err := credentials.DetectDefault(&credentials.DetectOptions{
-			Scopes:         []string{AlloyDBLoginScope},
+			Scopes:         []string{CloudPlatformScope},
 			UniverseDomain: d.getClientUniverseDomain(),
 		})
 		if err != nil {

--- a/options_test.go
+++ b/options_test.go
@@ -144,59 +144,38 @@ func TestWithUniverseDomain(t *testing.T) {
 	if cfg.universeDomain != want {
 		t.Errorf("got %q, want %q", cfg.universeDomain, want)
 	}
-	if got := cfg.getClientUniverseDomain(); got != want {
-		t.Errorf("getClientUniverseDomain() = %q, want %q", got, want)
+	if got := cfg.clientUniverseDomain(); got != want {
+		t.Errorf("clientUniverseDomain() = %q, want %q", got, want)
 	}
 }
 
-// TestUniverseDomainResolutionPrecedence verifies the 3-tier fallback order:
-// 1. Explicit Option -> 2. Environment Variable -> 3. Default "googleapis.com"
+// TestUniverseDomainResolutionPrecedence verifies the fallback order:
+// 1. Explicit Option -> 2. Default "googleapis.com"
 func TestUniverseDomainResolutionPrecedence(t *testing.T) {
 	tcs := []struct {
 		desc       string
 		opts       []Option
-		envValue   string
 		wantDomain string
 	}{
 		{
-			desc:       "default fallback when neither option nor env var is set",
+			desc:       "default fallback when option not set",
 			opts:       []Option{mockCreds},
-			envValue:   "",
 			wantDomain: defaultUniverseDomain, // "googleapis.com"
-		},
-		{
-			desc:       "resolves from GOOGLE_CLOUD_UNIVERSE_DOMAIN env var",
-			opts:       []Option{mockCreds},
-			envValue:   "env-universe.cloud",
-			wantDomain: "env-universe.cloud",
 		},
 		{
 			desc:       "resolves from explicit WithUniverseDomain option",
 			opts:       []Option{WithUniverseDomain("option-universe.cloud"), mockCreds},
-			envValue:   "",
-			wantDomain: "option-universe.cloud",
-		},
-		{
-			desc:       "explicit option overrides environment variable",
-			opts:       []Option{WithUniverseDomain("option-universe.cloud"), mockCreds},
-			envValue:   "env-universe.cloud",
 			wantDomain: "option-universe.cloud",
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			// t.Setenv automatically restores previous env state on test completion
-			if tc.envValue != "" {
-				t.Setenv(universeDomainEnvVar, tc.envValue)
-			} else {
-				t.Setenv(universeDomainEnvVar, "")
-			}
 			cfg, err := newDialerConfig(tc.opts...)
 			if err != nil {
 				t.Fatalf("newDialerConfig failed: %v", err)
 			}
-			if got := cfg.getClientUniverseDomain(); got != tc.wantDomain {
-				t.Errorf("getClientUniverseDomain() = %q, want %q", got, tc.wantDomain)
+			if got := cfg.clientUniverseDomain(); got != tc.wantDomain {
+				t.Errorf("clientUniverseDomain() = %q, want %q", got, tc.wantDomain)
 			}
 		})
 	}
@@ -233,8 +212,8 @@ func TestUniverseDomainWithCredentialsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newDialerConfig failed: %v", err)
 	}
-	if cfg.getClientUniverseDomain() != wantUniverseDomain {
-		t.Errorf("got %q, want %q", cfg.getClientUniverseDomain(), wantUniverseDomain)
+	if cfg.clientUniverseDomain() != wantUniverseDomain {
+		t.Errorf("got %q, want %q", cfg.clientUniverseDomain(), wantUniverseDomain)
 	}
 }
 
@@ -301,8 +280,8 @@ func TestNewDialerConfig_WrapsCredentialsWithUniverseDomain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newDialerConfig failed: %v", err)
 	}
-	if cfg.getClientUniverseDomain() != wantDomain {
-		t.Errorf("getClientUniverseDomain() = %q, want %q", cfg.getClientUniverseDomain(), wantDomain)
+	if cfg.clientUniverseDomain() != wantDomain {
+		t.Errorf("clientUniverseDomain() = %q, want %q", cfg.clientUniverseDomain(), wantDomain)
 	}
 	// Verify the wrapped credential used for dialer IAM AuthN provider matches the universe domain
 	wrappedCreds := WithUniverseDomainCredentials(gduCreds, wantDomain)

--- a/options_test.go
+++ b/options_test.go
@@ -16,11 +16,19 @@ package alloydbconn
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"testing"
 
 	"cloud.google.com/go/auth"
 	"golang.org/x/oauth2"
 )
+
+// Reusable mock credential to bypass ADC lookup
+var mockCreds = WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "mock-token"}))
 
 type nullTokenSource struct{}
 
@@ -123,4 +131,186 @@ func TestIAMAuthOptions(t *testing.T) {
 		})
 	}
 
+}
+
+// TestWithUniverseDomain verifies that WithUniverseDomain properly sets
+// the universeDomain field on dialerConfig and exports the client option.
+func TestWithUniverseDomain(t *testing.T) {
+	want := "my-universe.cloud"
+	cfg, err := newDialerConfig(WithUniverseDomain(want), mockCreds)
+	if err != nil {
+		t.Fatalf("newDialerConfig failed: %v", err)
+	}
+	if cfg.universeDomain != want {
+		t.Errorf("got %q, want %q", cfg.universeDomain, want)
+	}
+	if got := cfg.getClientUniverseDomain(); got != want {
+		t.Errorf("getClientUniverseDomain() = %q, want %q", got, want)
+	}
+}
+
+// TestUniverseDomainResolutionPrecedence verifies the 3-tier fallback order:
+// 1. Explicit Option -> 2. Environment Variable -> 3. Default "googleapis.com"
+func TestUniverseDomainResolutionPrecedence(t *testing.T) {
+	tcs := []struct {
+		desc       string
+		opts       []Option
+		envValue   string
+		wantDomain string
+	}{
+		{
+			desc:       "default fallback when neither option nor env var is set",
+			opts:       []Option{mockCreds},
+			envValue:   "",
+			wantDomain: defaultUniverseDomain, // "googleapis.com"
+		},
+		{
+			desc:       "resolves from GOOGLE_CLOUD_UNIVERSE_DOMAIN env var",
+			opts:       []Option{mockCreds},
+			envValue:   "env-universe.cloud",
+			wantDomain: "env-universe.cloud",
+		},
+		{
+			desc:       "resolves from explicit WithUniverseDomain option",
+			opts:       []Option{WithUniverseDomain("option-universe.cloud"), mockCreds},
+			envValue:   "",
+			wantDomain: "option-universe.cloud",
+		},
+		{
+			desc:       "explicit option overrides environment variable",
+			opts:       []Option{WithUniverseDomain("option-universe.cloud"), mockCreds},
+			envValue:   "env-universe.cloud",
+			wantDomain: "option-universe.cloud",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// t.Setenv automatically restores previous env state on test completion
+			if tc.envValue != "" {
+				t.Setenv(universeDomainEnvVar, tc.envValue)
+			} else {
+				t.Setenv(universeDomainEnvVar, "")
+			}
+			cfg, err := newDialerConfig(tc.opts...)
+			if err != nil {
+				t.Fatalf("newDialerConfig failed: %v", err)
+			}
+			if got := cfg.getClientUniverseDomain(); got != tc.wantDomain {
+				t.Errorf("getClientUniverseDomain() = %q, want %q", got, tc.wantDomain)
+			}
+		})
+	}
+}
+
+// TestUniverseDomainWithCredentialsJSON verifies credentials detection with universe domain.
+func TestUniverseDomainWithCredentialsJSON(t *testing.T) {
+	// Generate a valid mock RSA private key
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate mock private key: %v", err)
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal private key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+
+	// Format JSON with the valid PEM block using %q to escape newlines correctly
+	wantUniverseDomain := "my-universe.com"
+	credsJSON := []byte(fmt.Sprintf(`{
+      "type": "service_account",
+      "project_id": "test-project",
+      "private_key_id": "some-key-id",
+      "private_key": %q,
+      "client_email": "test@test-project.iam.gserviceaccount.com",
+      "universe_domain": %q
+    }`, string(keyPEM), wantUniverseDomain))
+
+	cfg, err := newDialerConfig(WithCredentialsJSON(credsJSON), WithUniverseDomain(wantUniverseDomain))
+	if err != nil {
+		t.Fatalf("newDialerConfig failed: %v", err)
+	}
+	if cfg.getClientUniverseDomain() != wantUniverseDomain {
+		t.Errorf("got %q, want %q", cfg.getClientUniverseDomain(), wantUniverseDomain)
+	}
+}
+
+// TestWithUniverseDomainCredentials verifies that credentials whose UniverseDomain
+// evaluates to "googleapis.com" (such as AuthorizedUser / Workforce Identity ADC)
+// are wrapped to report the configured universe domain.
+func TestWithUniverseDomainCredentials(t *testing.T) {
+	ctx := context.Background()
+	wantDomain := "apis-tpczero.goog"
+	// Create a mock credential whose UniverseDomainProvider defaults to "googleapis.com"
+	// to reproduce the Workforce Identity / AuthorizedUser credential behavior.
+	gduCreds := auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: fakeTokenProvider{},
+		ProjectIDProvider: auth.CredentialsPropertyFunc(func(_ context.Context) (string, error) {
+			return "test-project", nil
+		}),
+		UniverseDomainProvider: auth.CredentialsPropertyFunc(func(_ context.Context) (string, error) {
+			return "googleapis.com", nil
+		}),
+	})
+	// Verify original mock credentials report "googleapis.com"
+	origDomain, err := gduCreds.UniverseDomain(ctx)
+	if err != nil {
+		t.Fatalf("UniverseDomain() failed on mock creds: %v", err)
+	}
+	if origDomain != "googleapis.com" {
+		t.Fatalf("got %q, want %q", origDomain, "googleapis.com")
+	}
+	// Wrap the credentials with the custom universe domain
+	wrappedCreds := WithUniverseDomainCredentials(gduCreds, wantDomain)
+	// Verify wrapped credentials report "apis-tpczero.goog" and preserve properties
+	gotDomain, err := wrappedCreds.UniverseDomain(ctx)
+	if err != nil {
+		t.Fatalf("UniverseDomain() failed on wrapped creds: %v", err)
+	}
+	if gotDomain != wantDomain {
+		t.Errorf("wrapped UniverseDomain() = %q, want %q", gotDomain, wantDomain)
+	}
+	gotProject, err := wrappedCreds.ProjectID(ctx)
+	if err != nil {
+		t.Fatalf("ProjectID() failed on wrapped creds: %v", err)
+	}
+	if gotProject != "test-project" {
+		t.Errorf("wrapped ProjectID() = %q, want %q", gotProject, "test-project")
+	}
+}
+
+// TestNewDialerConfig_WrapsCredentialsWithUniverseDomain verifies that passing
+// WithCredentials with a non-matching universe domain along with WithUniverseDomain
+// wraps the credential attached to dialerConfig.
+func TestNewDialerConfig_WrapsCredentialsWithUniverseDomain(t *testing.T) {
+	ctx := context.Background()
+	wantDomain := "apis-tpczero.goog"
+	gduCreds := auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: fakeTokenProvider{},
+		UniverseDomainProvider: auth.CredentialsPropertyFunc(func(_ context.Context) (string, error) {
+			return "googleapis.com", nil
+		}),
+	})
+	cfg, err := newDialerConfig(
+		WithCredentials(gduCreds),
+		WithUniverseDomain(wantDomain),
+	)
+	if err != nil {
+		t.Fatalf("newDialerConfig failed: %v", err)
+	}
+	if cfg.getClientUniverseDomain() != wantDomain {
+		t.Errorf("getClientUniverseDomain() = %q, want %q", cfg.getClientUniverseDomain(), wantDomain)
+	}
+	// Verify the wrapped credential used for dialer IAM AuthN provider matches the universe domain
+	wrappedCreds := WithUniverseDomainCredentials(gduCreds, wantDomain)
+	gotDomain, err := wrappedCreds.UniverseDomain(ctx)
+	if err != nil {
+		t.Fatalf("failed to get domain: %v", err)
+	}
+	if gotDomain != wantDomain {
+		t.Errorf("got credential universe domain %q, want %q", gotDomain, wantDomain)
+	}
 }


### PR DESCRIPTION
Introduce support for custom Universe Domains, enabling the AlloyDB Go Connector to connect to instances running in Trusted Partner Cloud (TPC).

It adds the new WithUniverseDomain dialer option and ensures credentials detection and the underlying AlloyDB Admin API REST client resolve the target universe domain following Google Cloud client library conventions.

1. Add Option WithUniverseDomain to configure target universe domain on the dialer
2. Add helper clientUniverseDomain() with order of explicit option (WithUniverseDomain) -> Default ("googleapis.com")
3. Pass universeDomain to all credentials
4. Ensure dialer.go passes withUniverseDomain when using env var